### PR TITLE
Call networkOptions.complete in login command

### DIFF
--- a/pkg/cmd/login/cmd.go
+++ b/pkg/cmd/login/cmd.go
@@ -147,6 +147,10 @@ func (opts *loginOptions) complete(ctx context.Context, args []string) error {
 		}
 	}
 
+	if err := opts.NetworkOptions.Complete(ctx, args); err != nil {
+		return err
+	}
+
 	return nil
 }
 


### PR DESCRIPTION
### Description
We had missed a call to 'complete' the network options in the login command. This leads to network options around auth being ignored (specifically, the `KITOPS_CLIENT_CERT` and `KITOPS_CLIENT_KEY` env vars, plus the path to stored credentials.

### Linked issues
Closes https://github.com/kitops-ml/kitops/issues/786