### PR TITLE
Update numbering in hf-import.md

### DIFF
--- a/docs/src/docs/hf-import.md
+++ b/docs/src/docs/hf-import.md
@@ -15,14 +15,14 @@ You can read more about the `import` command in our [CLI reference](../cli/cli-r
 
 1. **Get the HF URL**: On the Hugging Face site, copy the URL from the repository you want to create a ModelKit from (e.g., https://huggingface.co/HuggingFaceTB/SmolLM-135M-Instruct). You can also customize the name or add a tag name if desired.
 
-1. **Kit import**: In a terminal window running Kit version 1.0.0 at least, type `kit import https://huggingface.co/HuggingFaceTB/SmolLM-135M-Instruct`. This will download and build a [Kitfile](../kitfile/kf-overview/) based on the Hugging Face model and give you an opportunity to edit it before the ModelKit is packed.
+2. **Kit import**: In a terminal window running Kit version 1.0.0 at least, type `kit import https://huggingface.co/HuggingFaceTB/SmolLM-135M-Instruct`. This will download and build a [Kitfile](../kitfile/kf-overview/) based on the Hugging Face model and give you an opportunity to edit it before the ModelKit is packed.
 
 ::: tip
 If you have a [Huggingface Access Token](https://huggingface.co/docs/hub/security-tokens) you can specify it using the `--token` flag for `kit import`.
 :::
 
-1. **Auto-generate the ModelKit**: Once the Kitfile is accepted a ModelKit will be built and saved to your local registry using the name you selected. If you didn't specify a tag name the ModelKit will be tagged `latest`.
+3. **Auto-generate the ModelKit**: Once the Kitfile is accepted a ModelKit will be built and saved to your local registry using the name you selected. If you didn't specify a tag name the ModelKit will be tagged `latest`.
 
-1. **Admire your new ModelKit**: Typing `kit list` will show you the list of ModelKits on your system and you'll see the newly imported tag (e.g., `HuggingFaceTB/SmolLM-135M-Instruct:latest`).
+4. **Admire your new ModelKit**: Typing `kit list` will show you the list of ModelKits on your system and you'll see the newly imported tag (e.g., `HuggingFaceTB/SmolLM-135M-Instruct:latest`).
 
 That's it! So easy! Now go out there and start sharing your favourite Hugging Face models through your OCI registry!


### PR DESCRIPTION
### Description
<!-- describe the changes in this PR -->
The original documentation had an ordered list with incorrect numbering (displayed as `1, 2, 1, 2` instead of sequential `1-4`) due to Markdown syntax conflicts with the `::: tip` admonition block.

- Fixed list numbering to ensure sequential order (1 → 4)
