### PR TITLE
Print update notification messages to stderr instead of stdout

### DIFF
--- a/pkg/lib/update/update.go
+++ b/pkg/lib/update/update.go
@@ -78,10 +78,10 @@ func CheckForUpdate(configHome string) {
 	currentVersion := fmt.Sprintf("v%s", strings.TrimPrefix(constants.Version, "v"))
 	latestVersion := fmt.Sprintf("v%s", strings.TrimPrefix(info.TagName, "v"))
 	if semver.Compare(currentVersion, latestVersion) < 0 {
-		output.Infof("Note: A new version of Kit is available! You are using Kit %s. The latest version is %s.", currentVersion, latestVersion)
-		output.Infof("      To see a list of changes, visit %s", info.Url)
-		output.Infof("      To disable this notification, use 'kit version --show-update-notifications=false'")
-		output.Infof("") // Add a newline to not confuse it with regular output
+		output.SystemInfof("Note: A new version of Kit is available! You are using Kit %s. The latest version is %s.", currentVersion, latestVersion)
+		output.SystemInfof("      To see a list of changes, visit %s", info.Url)
+		output.SystemInfof("      To disable this notification, use 'kit version --show-update-notifications=false'")
+		output.SystemInfof("") // Add a newline to not confuse it with regular output
 	}
 }
 

--- a/pkg/output/logging.go
+++ b/pkg/output/logging.go
@@ -73,6 +73,18 @@ func SafeDebugf(s string, args ...any) {
 	SafeLogf(LogLevelDebug, s, args...)
 }
 
+// SystemInfoLn is like Infoln except it logs to stderr. This should be used
+// for system messages such as update notifications
+func SystemInfoln(s any) {
+	loglnTo(stderr, LogLevelInfo, s)
+}
+
+// SystemInfof is like Infof except it logs to stder. This should be used
+// for system messages such as update notifications
+func SystemInfof(s string, args ...any) {
+	logfTo(stderr, LogLevelInfo, s, args)
+}
+
 func Logln(level LogLevel, s any) {
 	loglnTo(level.getOutput(), level, s)
 }


### PR DESCRIPTION
### Description
Print update notification message to stderr so that it is not included when output is redirected to file.

### Linked issues
Closes #801 