### PR TITLE
Fix typo in flags for MacOS goreleaser build

### DIFF
--- a/.goreleaser.darwin.yaml
+++ b/.goreleaser.darwin.yaml
@@ -18,7 +18,7 @@ builds:
       - arm64
     binary: kit
     ldflags:
-      - -s -w -X github.com/kitops-ml/kitops/pkg/lib/constants.Version={{.Version}} -X kigithub.com/kitops-ml/kitops/pkg/lib/constants.GitCommit={{.Commit}} -X github.com/kitops-ml/kitops/pkg/lib/constants.BuildTime={{.CommitDate}}
+      - -s -w -X github.com/kitops-ml/kitops/pkg/lib/constants.Version={{.Version}} -X github.com/kitops-ml/kitops/pkg/lib/constants.GitCommit={{.Commit}} -X github.com/kitops-ml/kitops/pkg/lib/constants.BuildTime={{.CommitDate}}
     hooks:
       post:
         - cmd: ./build/scripts/sign '{{ .Path }}'


### PR DESCRIPTION
### Description
Fix typo from previous commits updating everything to `kitops-ml`

### Linked issues
N/A