### PR TITLE
Fix ghcr.io package references after move to kitops-ml org

### DIFF
--- a/build/dockerfiles/KServe/Dockerfile
+++ b/build/dockerfiles/KServe/Dockerfile
@@ -1,4 +1,4 @@
-ARG KIT_BASE_IMAGE=ghcr.io/kitops-ml/kit:next
+ARG KIT_BASE_IMAGE=ghcr.io/kitops-ml/kitops:next
 FROM $KIT_BASE_IMAGE
 
 COPY entrypoint.sh /usr/local/bin/entrypoint.sh

--- a/build/dockerfiles/KServe/README.md
+++ b/build/dockerfiles/KServe/README.md
@@ -8,10 +8,10 @@ To build the image, `docker` or `podman` is required. From the root of this repo
 docker build -t $KIT_KSERVE_IMAGE .
 ```
 
-By default, the image will be built using `ghcr.io/kitops-ml/kit:next` as a base. This can be overridden (to build using a specific version of Kit, for example) by using the build arg `KIT_BASE_IMAGE`:
+By default, the image will be built using `ghcr.io/kitops-ml/kitops:next` as a base. This can be overridden (to build using a specific version of Kit, for example) by using the build arg `KIT_BASE_IMAGE`:
 ```shell
-# Build the image based on Kit v0.3.2 instead of 'next'
-docker build -t kit-init-container:latest --build-arg KIT_BASE_IMAGE=ghcr.io/kitops-ml/kit:v0.3.2 .
+# Build the image based on Kit v1.3.0 instead of 'next'
+docker build -t kit-init-container:latest --build-arg KIT_BASE_IMAGE=ghcr.io/kitops-ml/kitops:v1.3.0 .
 ```
 
 ## Installing

--- a/build/dockerfiles/README.md
+++ b/build/dockerfiles/README.md
@@ -3,7 +3,7 @@
 The Dockerfiles in this directory can be used for building a containerized version of the Kit CLI. The default entrypoint
 for these image is invoking the `kit` CLI, allowing for quickly running Kit commands without needing to install the CLI:
 ```
-docker run --rm ghcr.io/kitops-ml/kit:latest version
+docker run --rm ghcr.io/kitops-ml/kitops:latest version
 ```
 
 ## Release build

--- a/build/dockerfiles/init/README.md
+++ b/build/dockerfiles/init/README.md
@@ -70,9 +70,9 @@ Building the image requires docker or podman. To build the image, run the follow
 docker build -t kit-init-container:latest .
 ```
 
-By default, the image will be built using `ghcr.io/kitops-ml/kit:next` as a base. This can be overridden (to build using a specific version of Kit, for example) by using the build arg `KIT_BASE_IMAGE`:
+By default, the image will be built using `ghcr.io/kitops-ml/kitops:next` as a base. This can be overridden (to build using a specific version of Kit, for example) by using the build arg `KIT_BASE_IMAGE`:
 
 ```shell
-# Build the image based on Kit v0.3.2 instead of 'next'
-docker build -t kit-init-container:latest --build-arg KIT_BASE_IMAGE=ghcr.io/kitops-ml/kit:v0.3.2 .
+# Build the image based on Kit v1.3.0 instead of 'next'
+docker build -t kit-init-container:latest --build-arg KIT_BASE_IMAGE=ghcr.io/kitops-ml/kitops:v1.3.0 .
 ```

--- a/docs/src/docs/deploy.md
+++ b/docs/src/docs/deploy.md
@@ -69,7 +69,7 @@ This container runs `kit` as its entrypoint, accepting Kit CLI arguments. So you
 
 Docker run example:
 
-`docker run ghcr.io/kitops-ml/kit:latest pull jozu.ml/jozu/llama3-8b:8B-instruct-q5_0`
+`docker run ghcr.io/kitops-ml/kitops:latest pull jozu.ml/jozu/llama3-8b:8B-instruct-q5_0`
 
 Kubernetes example:
 
@@ -81,7 +81,7 @@ Kubernetes example:
  spec:
    containers:
      - name: me-using-kit
-       image: ghcr.io/kitops-ml/kit:latest
+       image: ghcr.io/kitops-ml/kitops:latest
        args: # You can put whatever you want; args is an array
          - pull
          - jozu.ml/jozu/llama3-8b:8B-instruct-q5_0
@@ -95,7 +95,7 @@ Example `dockerfile` for a custom container that has `my-modelkit` built into it
 
 ```
  # Staged build to grab the ModelKit so we can use it later
- FROM ghcr.io/kitops-ml/kit:latest AS modelkit-download
+ FROM ghcr.io/kitops-ml/kitops:latest AS modelkit-download
 
  # Download your ModelKit into the container
  RUN kit unpack my-modelkit /tmp/my-modelkit


### PR DESCRIPTION

### Description
At some point, the base kit package in ghcr changed from kit to kitops so some references were out of date.

### Linked issues
Related: #817 