### PR TITLE
Use monolithic PUT to upload large layers to Amazon ECR

### DIFF
--- a/pkg/lib/repo/remote/upload-format.go
+++ b/pkg/lib/repo/remote/upload-format.go
@@ -17,8 +17,9 @@
 package remote
 
 import (
-	"github.com/kitops-ml/kitops/pkg/output"
 	"regexp"
+
+	"github.com/kitops-ml/kitops/pkg/output"
 )
 
 type uploadFormat int
@@ -34,8 +35,9 @@ const (
 )
 
 var (
-	googleArtifactRegistryRegexp  = regexp.MustCompile(`.*\.pkg\.dev$`)
-	googleContainerRegistryRegexp = regexp.MustCompile(`.*\.?gcr.io$`)
+	googleArtifactRegistryRegexp         = regexp.MustCompile(`.*\.pkg\.dev$`)
+	googleContainerRegistryRegexp        = regexp.MustCompile(`.*\.?gcr\.io$`)
+	amazonElasticContainerRegistryRegexp = regexp.MustCompile(`.*\.?amazonaws\.com(\.cn)?$`)
 )
 
 func getUploadFormat(registry string, size int64) uploadFormat {
@@ -49,6 +51,10 @@ func getUploadFormat(registry string, size int64) uploadFormat {
 		// Google Artifact Registry does not support chunked uploads and instead requires monolithic
 		// uploads.
 		// docs: https://cloud.google.com/artifact-registry/docs/docker/pushing-and-pulling#pushing
+		return uploadMonolithicPut
+	case amazonElasticContainerRegistryRegexp.MatchString(registry):
+		// Amazon ECR returns an HTTP 201 after the first piece in a multi-part upload, which causes
+		// uploads to fail.
 		return uploadMonolithicPut
 	default:
 		// No matches above, use heuristic

--- a/pkg/lib/repo/remote/upload-format.go
+++ b/pkg/lib/repo/remote/upload-format.go
@@ -18,6 +18,7 @@ package remote
 
 import (
 	"regexp"
+	"strings"
 
 	"github.com/kitops-ml/kitops/pkg/output"
 )
@@ -42,6 +43,7 @@ var (
 
 func getUploadFormat(registry string, size int64) uploadFormat {
 	output.SafeDebugf("Getting upload format for: %s", registry)
+	registry = strings.ToLower(registry)
 	switch {
 	case registry == "ghcr.io":
 		// ghcr.io returns 416 is a PATCH has Content-Length greater than 4.0 MiB for some reason

--- a/pkg/lib/repo/remote/upload-format_test.go
+++ b/pkg/lib/repo/remote/upload-format_test.go
@@ -101,3 +101,30 @@ func TestGetUploadFormatGoogleArtifactRegistry(t *testing.T) {
 		assert.Equal(t, uploadMonolithicPut, uploadFormatLarge, "Large layers should use monolithic put")
 	}
 }
+
+func TestGetUploadFormatAmazonECR(t *testing.T) {
+	testRegistries := []string{
+		"123918541723.dkr.ecr.us-east-2.amazonaws.com",
+		"123918541723.dkr.ecr-fips.us-east-1.amazonaws.com",
+		"123918541723.dkr.ecr-fips.us-west-2.amazonaws.com",
+		"123918541723.dkr.ecr.ap-south-1.amazonaws.com",
+		"123918541723.dkr.ecr.ap-northeast-1.amazonaws.com",
+		"123918541723.dkr.ecr.ca-central-1.amazonaws.com",
+		"123918541723.dkr.ecr.cn-north-1.amazonaws.com.cn",
+		"123918541723.dkr.ecr.cn-northwest-1.amazonaws.com.cn",
+		"123918541723.dkr.ecr.eu-central-1.amazonaws.com",
+		"123918541723.dkr.ecr.eu-west-1.amazonaws.com",
+		"123918541723.dkr.ecr.me-south-1.amazonaws.com",
+		"123918541723.dkr.ecr.sa-east-1.amazonaws.com",
+		"123918541723.dkr.ecr-fips.us-gov-east-1.amazonaws.com",
+		"123918541723.dkr.ecr.us-gov-west-1.amazonaws.com",
+		"123918541723.dkr.ecr-fips.us-gov-west-1.amazonaws.com",
+	}
+
+	for _, registry := range testRegistries {
+		uploadFormatSmall := getUploadFormat(registry, 100)
+		assert.Equal(t, uploadMonolithicPut, uploadFormatSmall, "Small layers should use monolithic put")
+		uploadFormatLarge := getUploadFormat(registry, uploadChunkDefaultSize)
+		assert.Equal(t, uploadMonolithicPut, uploadFormatLarge, "Large layers should use monolithic put")
+	}
+}

--- a/pkg/lib/repo/remote/upload-format_test.go
+++ b/pkg/lib/repo/remote/upload-format_test.go
@@ -92,6 +92,8 @@ func TestGetUploadFormatGoogleArtifactRegistry(t *testing.T) {
 		"northamerica-northeast1-docker.pkg.dev",
 		"us-central1-docker.pkg.dev",
 		"us-east1-docker.pkg.dev",
+		".PKG.DEV",
+		".pkg.DEV",
 	}
 
 	for _, registry := range testRegistries {
@@ -119,6 +121,8 @@ func TestGetUploadFormatAmazonECR(t *testing.T) {
 		"123918541723.dkr.ecr-fips.us-gov-east-1.amazonaws.com",
 		"123918541723.dkr.ecr.us-gov-west-1.amazonaws.com",
 		"123918541723.dkr.ecr-fips.us-gov-west-1.amazonaws.com",
+		"123918541723.dkr.ecr.us-east-2.AmAzOnAwS.com",
+		"123918541723.dkr.ecr.us-east-2.AMAZONAWS.COM",
 	}
 
 	for _, registry := range testRegistries {


### PR DESCRIPTION
### Description
Amazon ECR registries return HTTP 201 after the first chunk in a multi-part upload, which is unexpected and causes the upload to fail. To avoid this, we can default to using a monolithic PUT.

### Linked issues
Closes #821 