### PR TITLE
Import specific version

### DIFF
--- a/pkg/cmd/kitimport/cmd.go
+++ b/pkg/cmd/kitimport/cmd.go
@@ -58,6 +58,9 @@ REPOSITORY.`
 	example = `# Download repository myorg/myrepo and package it, using the default tag (myorg/myrepo:latest)
 kit import myorg/myrepo
 
+# Download repository using a different version (tag) than the default and package it
+kit import myorg/myrepo --ref v1.0.0
+
 # Download repository and tag it 'myrepository:mytag'
 kit import myorg/myrepo --tag myrepository:mytag
 
@@ -68,6 +71,7 @@ kit import myorg/myrepo --file ./path/to/Kitfile`
 type importOptions struct {
 	configHome   string
 	repo         string
+	repoRef      string
 	tag          string
 	token        string
 	kitfilePath  string
@@ -88,6 +92,7 @@ func ImportCommand() *cobra.Command {
 		Args:    cobra.ExactArgs(1),
 	}
 
+	cmd.Flags().StringVar(&opts.repoRef, "ref", "main", "Version (tag) of repository to import (default is 'main')")
 	cmd.Flags().StringVar(&opts.token, "token", "", "Token to use for authenticating with repository")
 	cmd.Flags().StringVarP(&opts.tag, "tag", "t", "", "Tag for the ModelKit (default is '[repository]:latest')")
 	cmd.Flags().StringVarP(&opts.kitfilePath, "file", "f", "", "Path to Kitfile to use for packing (use '-' to read from standard input)")

--- a/pkg/cmd/kitimport/cmd.go
+++ b/pkg/cmd/kitimport/cmd.go
@@ -24,6 +24,7 @@ import (
 	"strings"
 
 	"github.com/kitops-ml/kitops/pkg/lib/constants"
+	"github.com/kitops-ml/kitops/pkg/lib/git"
 	repoutils "github.com/kitops-ml/kitops/pkg/lib/repo/util"
 	"github.com/kitops-ml/kitops/pkg/output"
 
@@ -92,7 +93,7 @@ func ImportCommand() *cobra.Command {
 		Args:    cobra.ExactArgs(1),
 	}
 
-	cmd.Flags().StringVar(&opts.repoRef, "ref", "main", "Version (tag) of repository to import (default is 'main')")
+	cmd.Flags().StringVar(&opts.repoRef, "ref", git.DefaultGitRef, "Version (tag) of repository to import")
 	cmd.Flags().StringVar(&opts.token, "token", "", "Token to use for authenticating with repository")
 	cmd.Flags().StringVarP(&opts.tag, "tag", "t", "", "Tag for the ModelKit (default is '[repository]:latest')")
 	cmd.Flags().StringVarP(&opts.kitfilePath, "file", "f", "", "Path to Kitfile to use for packing (use '-' to read from standard input)")

--- a/pkg/cmd/kitimport/gitimport.go
+++ b/pkg/cmd/kitimport/gitimport.go
@@ -47,7 +47,7 @@ func importUsingGit(ctx context.Context, opts *importOptions) error {
 		}
 	}()
 
-	if err := cloneRepository(opts.repo, tmpDir, opts.token); err != nil {
+	if err := cloneRepository(opts.repo, opts.repoRef, tmpDir, opts.token); err != nil {
 		return err
 	}
 
@@ -117,12 +117,12 @@ func importUsingGit(ctx context.Context, opts *importOptions) error {
 	return nil
 }
 
-func cloneRepository(repo, destDir, token string) error {
+func cloneRepository(repo, repoRef, destDir, token string) error {
 	fullRepo := repo
 	if !strings.HasPrefix(fullRepo, "http") {
 		fullRepo = fmt.Sprintf("https://huggingface.co/%s", repo)
 	}
-	if err := git.CloneRepository(fullRepo, destDir, token); err != nil {
+	if err := git.CloneRepository(fullRepo, repoRef, destDir, token); err != nil {
 		return err
 	}
 	// Clean up git-related files, since we probably don't want those

--- a/pkg/cmd/kitimport/hfimport.go
+++ b/pkg/cmd/kitimport/hfimport.go
@@ -53,7 +53,7 @@ func importUsingHF(ctx context.Context, opts *importOptions) error {
 		}
 	}()
 
-	dirListing, err := hf.ListFiles(ctx, repo, opts.token)
+	dirListing, err := hf.ListFiles(ctx, repo, opts.repoRef, opts.token)
 	if err != nil {
 		return fmt.Errorf("failed to list files from HuggingFace API: %w", err)
 	}
@@ -106,7 +106,7 @@ func importUsingHF(ctx context.Context, opts *importOptions) error {
 	if err != nil {
 		return err
 	}
-	if err := hf.DownloadFiles(ctx, repo, tmpDir, toDownload, opts.token, opts.concurrency); err != nil {
+	if err := hf.DownloadFiles(ctx, repo, opts.repoRef, tmpDir, toDownload, opts.token, opts.concurrency); err != nil {
 		return fmt.Errorf("error downloading repository: %w", err)
 	}
 

--- a/pkg/lib/git/clone.go
+++ b/pkg/lib/git/clone.go
@@ -26,7 +26,9 @@ import (
 	"github.com/kitops-ml/kitops/pkg/output"
 )
 
-func CloneRepository(repo, dest, token string) error {
+const DefaultGitRef = "main"
+
+func CloneRepository(repo, repoRef, dest, token string) error {
 	if err := checkGit(); err != nil {
 		return err
 	}
@@ -53,7 +55,12 @@ func CloneRepository(repo, dest, token string) error {
 	}
 
 	// Clone without LFS enabled to get metadata about repo first
-	cloneCmd := exec.Command("git", "clone", "--depth", "1", repo, dest)
+	var cloneCmd *exec.Cmd
+	if repoRef != DefaultGitRef {
+		cloneCmd = exec.Command("git", "clone", "--depth", "1", "--branch", repoRef, "-c", "advice.detachedHead=false", repo, dest)
+	} else {
+		cloneCmd = exec.Command("git", "clone", "--depth", "1", repo, dest)
+	}
 	cloneCmd.Env = cloneEnv
 	cloneCmd.Env = append(cloneCmd.Env, "GIT_LFS_SKIP_SMUDGE=1")
 	cloneCmd.Stderr = os.Stderr

--- a/pkg/lib/hf/download.go
+++ b/pkg/lib/hf/download.go
@@ -34,12 +34,12 @@ import (
 )
 
 const (
-	resolveURLFmt = "https://huggingface.co/%s/resolve/main/%s"
+	resolveURLFmt = "https://huggingface.co/%s/resolve/%s/%s"
 )
 
 func DownloadFiles(
 	ctx context.Context,
-	modelRepo, destDir string,
+	modelRepo, repoRef, destDir string,
 	filepaths []string,
 	token string,
 	maxConcurrency int) error {
@@ -61,7 +61,7 @@ func DownloadFiles(
 			break
 		}
 
-		fileURL := fmt.Sprintf(resolveURLFmt, modelRepo, f)
+		fileURL := fmt.Sprintf(resolveURLFmt, modelRepo, repoRef, f)
 		destPath := filepath.Join(destDir, f)
 		errs.Go(func() error {
 			defer sem.Release(1)

--- a/pkg/lib/hf/list.go
+++ b/pkg/lib/hf/list.go
@@ -30,7 +30,7 @@ import (
 )
 
 const (
-	treeURLFmt = "https://huggingface.co/api/models/%s/tree/main"
+	treeURLFmt = "https://huggingface.co/api/models/%s/tree/%s"
 )
 
 type hfTreeResponse []struct {
@@ -44,11 +44,11 @@ type hfErrorResponse struct {
 	Error string `json:"error"`
 }
 
-func ListFiles(ctx context.Context, modelRepo string, token string) (*kfgen.DirectoryListing, error) {
+func ListFiles(ctx context.Context, modelRepo, ref string, token string) (*kfgen.DirectoryListing, error) {
 	client := &http.Client{
 		Timeout: 10 * time.Second,
 	}
-	baseURL, err := url.Parse(fmt.Sprintf(treeURLFmt, modelRepo))
+	baseURL, err := url.Parse(fmt.Sprintf(treeURLFmt, modelRepo, ref))
 	if err != nil {
 		return nil, fmt.Errorf("failed to parse URL: %w", err)
 	}


### PR DESCRIPTION
### Description
Add flag `--ref` to `kit import` command to allow specifying a revision (i.e. other than `main`) to import. Supported by both the git and hf importer.

To test, it's convenient to use 
* Default branch: `kit import HuggingFaceTB/SmolLM-135M-Instruct`
* v0.1 branch: `kit import HuggingFaceTB/SmolLM-135M-Instruct --ref v0.1`

### Linked issues
Closes #823 