### PR TITLE
feature: Conditional login to AWS ECR using IRSA based on ENVs

### DIFF
--- a/build/dockerfiles/Dockerfile
+++ b/build/dockerfiles/Dockerfile
@@ -21,7 +21,7 @@ ENV USER_ID=1001 \
     HOME=/home/user/
 
 RUN apk --no-cache upgrade && \
-    apk add --no-cache bash git git-lfs && \
+    apk add --no-cache aws-cli bash git git-lfs && \
     git-lfs install --system && \
     mkdir -p /home/user/ && \
     adduser -D $USER_NAME -h $HOME -u $USER_ID

--- a/build/dockerfiles/KServe/README.md
+++ b/build/dockerfiles/KServe/README.md
@@ -27,7 +27,7 @@ spec:
         cpu: 100m
       limits:
         memory: 1Gi
-    supportedUriFormats:
+  supportedUriFormats:
     - prefix: kit://
 ```
 
@@ -70,6 +70,16 @@ The Kit KServe container supports specifying additional flags for the `kit unpac
       - name: KIT_UNPACK_FLAGS
         value: "-v --plain-http"
 ```
+
+To use AWS IRSA credentials, set the following environment variables:
+
+```yaml
+    env:
+      - name: AWS_ECR_REGION
+        value: "" # AWS region of ECR repository containing artifacts
+```
+
+Loggin into AWS ECR using IRSA is conditional based on the presence of the `AWS_ROLE_ARN` environment variable which is set automatically by Kubernetes service account containing proper annotation.
 
 ## Additional links
 

--- a/build/dockerfiles/KServe/entrypoint.sh
+++ b/build/dockerfiles/KServe/entrypoint.sh
@@ -6,6 +6,8 @@ echo "Binary version info:"
 kit version
 
 read -r -a UNPACK_FLAGS <<< "$KIT_UNPACK_FLAGS"
+read -r AWS_ECR_REGION <<< "$AWS_ECR_REGION"
+read -r AWS_ROLE_ARN <<< "$AWS_ROLE_ARN"
 
 if [ $# != 2 ]; then
   echo "Usage: entrypoint.sh <src-uri> <dest-path>"
@@ -15,9 +17,18 @@ fi
 REPO_NAME="${1#kit://}"
 OUTPUT_DIR="$2"
 
+if [ -n "$AWS_ROLE_ARN" ]; then
+  AWS_ACCOUNT_ID=$(echo "$AWS_ROLE_ARN" | cut -d: -f5)
+  echo "Logging into AWS ECR $AWS_ACCOUNT_ID.dkr.ecr.$AWS_ECR_REGION.amazonaws.com"
+  aws ecr get-login-password --region $AWS_ECR_REGION | kit login --username AWS --password-stdin $AWS_ACCOUNT_ID.dkr.ecr.$AWS_ECR_REGION.amazonaws.com
+fi
+
 echo "Unpacking $REPO_NAME to $OUTPUT_DIR"
 echo "Unpack options: ${KIT_UNPACK_FLAGS}"
 kit unpack "$REPO_NAME" -d "$OUTPUT_DIR" "${UNPACK_FLAGS[@]}"
 
-echo "Unpacked modelkit:"
-cat "$OUTPUT_DIR/Kitfile"
+if [ -f "$OUTPUT_DIR/Kitfile" ]; then
+  echo "Unpacked modelkit:"
+  cat "$OUTPUT_DIR/Kitfile"
+fi
+


### PR DESCRIPTION
### Description
This PR introduces possibility to set and use AWS IRSA to perform authentication within Kubernetes. 
It is conditional on environment variable specific flags: `AWS_ROLE_ARN` which is automatically set by Kubernetes when service account used for `InferenceService` has `eks.amazonaws.com/role-arn: arn:aws:iam::<ACCOUNT_ID>:role/<ROLE_NAME>` annotation set and `AWS_ECR_REGION` which points to ECR region holding wanted artifacts.

Additionally - because Kitfile unpack might be omitted when user sets `UNPACK_FLAGS` - preview of Kitfile in entrypoint is also conditional.

### Linked issues
fixes https://github.com/kitops-ml/kitops/issues/817
