### PR TITLE
Fix the blog posts json

### DIFF
--- a/docs/.vitepress/theme/posts.json
+++ b/docs/.vitepress/theme/posts.json
@@ -637,7 +637,7 @@
     "tags": [
       "KitOps",
       "Open-Source",
-      "AWS",
+      "AWS"
     ],
     "author": "Jesse Williams",
     "published_time": "2025-03-14"
@@ -648,7 +648,7 @@
     "tags": [
       "KitOps",
       "Open-Source",
-      "PyData",
+      "PyData"
     ],
     "author": "Shivay Lamba",
     "published_time": "2025-04-08"


### PR DESCRIPTION
There are two bad trailing commas in the blog posts.json file which are breaking the build. This PR fixes that.