### PR TITLE
Fix unpacking referenced ModelKits when filters are used

### DIFF
--- a/pkg/cmd/dev/opts.go
+++ b/pkg/cmd/dev/opts.go
@@ -22,7 +22,6 @@ import (
 
 	"github.com/kitops-ml/kitops/pkg/lib/constants"
 	"github.com/kitops-ml/kitops/pkg/lib/filesystem"
-	"github.com/kitops-ml/kitops/pkg/output"
 )
 
 type DevBaseOptions struct {
@@ -34,7 +33,7 @@ type DevLogsOptions struct {
 	follow bool
 }
 
-func (opts *DevBaseOptions) complete(ctx context.Context, args []string) error {
+func (opts *DevBaseOptions) complete(ctx context.Context, _ []string) error {
 	configHome, ok := ctx.Value(constants.ConfigKey{}).(string)
 	if !ok {
 		return fmt.Errorf("default config path not set on command context")
@@ -74,8 +73,7 @@ func (opts *DevStartOptions) complete(ctx context.Context, args []string) error 
 	if opts.port == 0 {
 		availPort, err := findAvailablePort()
 		if err != nil {
-			output.Fatalf("Invalid arguments: %s", err)
-			return err
+			return fmt.Errorf("Invalid arguments: %s", err)
 		}
 		opts.port = availPort
 	}

--- a/pkg/cmd/version/version.go
+++ b/pkg/cmd/version/version.go
@@ -46,18 +46,19 @@ func VersionCommand() *cobra.Command {
 		Use:   "version",
 		Short: shortDesc,
 		Long:  longDesc,
-		Run: func(cmd *cobra.Command, args []string) {
+		RunE: func(cmd *cobra.Command, args []string) error {
 			if cmd.Flags().Changed(versionNotifFlag) {
 				configHome, ok := cmd.Context().Value(constants.ConfigKey{}).(string)
 				if !ok {
-					output.Fatalln("default config path not set on command context")
+					return output.Fatalln("default config path not set on command context")
 				}
 				if err := update.SetShowNotifications(configHome, opts.shouldShowNotifications); err != nil {
-					output.Fatalln(err)
+					return output.Fatalln(err)
 				}
 			} else {
 				output.Infof("Version: %s\nCommit: %s\nBuilt: %s\nGo version: %s\n", constants.Version, constants.GitCommit, constants.BuildTime, constants.GoVersion)
 			}
+			return nil
 		},
 	}
 	cmd.Flags().BoolVar(&opts.shouldShowNotifications, versionNotifFlag, false, "Enable or disable update notifications for the Kit CLI")

--- a/pkg/lib/kitfile/layer.go
+++ b/pkg/lib/kitfile/layer.go
@@ -153,7 +153,7 @@ func writeLayerToTar(basePath string, ignore filesystem.IgnorePaths, tarWriter *
 		return true
 	}
 
-	filepath.Walk(".", func(file string, fi os.FileInfo, err error) error {
+	err = filepath.Walk(".", func(file string, fi os.FileInfo, err error) error {
 		if err != nil {
 			return err
 		}
@@ -192,6 +192,9 @@ func writeLayerToTar(basePath string, ignore filesystem.IgnorePaths, tarWriter *
 		}
 		return writeFileToTar(file, fi, tarWriter, plog)
 	})
+	if err != nil {
+		return err
+	}
 
 	return nil
 }

--- a/pkg/lib/repo/local/util.go
+++ b/pkg/lib/repo/local/util.go
@@ -20,12 +20,10 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
-	"net/url"
 	"os"
 
 	"github.com/opencontainers/image-spec/specs-go"
 	ocispec "github.com/opencontainers/image-spec/specs-go/v1"
-	"oras.land/oras-go/v2/registry"
 )
 
 // parseIndexJson parses an OCI index at specified path
@@ -80,16 +78,4 @@ func canSafelyDeleteManifest(ctx context.Context, storagePath string, desc ocisp
 		}
 	}
 	return refCount <= 1, nil
-}
-
-func getBaseBlobDownloadUrl(ref registry.Reference, plainHttp bool) string {
-	scheme := "https"
-	if plainHttp {
-		scheme = "http"
-	}
-	return fmt.Sprintf("%s://%s/v2/%s/blobs/", scheme, ref.Host(), ref.Repository)
-}
-
-func blobUrlForDescriptor(baseUrl string, digest string) (string, error) {
-	return url.JoinPath(baseUrl, digest)
 }


### PR DESCRIPTION
### Description
Fix how unpack filters are handled when unpacking referenced ModelKits. Previously, since we only want the model from a referenced ModelKit, we were using a `--filter=model` filter to avoid unpacking other elements of the ModelKit. However, this filter was overwriting any user-provided filters through the `--filter` flag.

This PR also fixes a few minor linter warnings I came across.

### Linked issues
Closes #840 