### PR TITLE
Fix Docker image installed tools

### DIFF
--- a/build/dockerfiles/Dockerfile
+++ b/build/dockerfiles/Dockerfile
@@ -21,7 +21,7 @@ ENV USER_ID=1001 \
     HOME=/home/user/
 
 RUN apk --no-cache upgrade && \
-    apk add --no-cache aws-cli bash git git-lfs && \
+    apk add --no-cache bash git git-lfs && \
     git-lfs install --system && \
     mkdir -p /home/user/ && \
     adduser -D $USER_NAME -h $HOME -u $USER_ID

--- a/build/dockerfiles/KServe/Dockerfile
+++ b/build/dockerfiles/KServe/Dockerfile
@@ -1,6 +1,11 @@
 ARG KIT_BASE_IMAGE=ghcr.io/kitops-ml/kitops:next
 FROM $KIT_BASE_IMAGE
 
+USER 0
+RUN apk --no-cache upgrade && \
+    apk add --no-cache aws-cli
+USER 1001
+
 COPY entrypoint.sh /usr/local/bin/entrypoint.sh
 
 ENTRYPOINT ["/usr/local/bin/entrypoint.sh"]

--- a/build/dockerfiles/release.Dockerfile
+++ b/build/dockerfiles/release.Dockerfile
@@ -34,7 +34,7 @@ ENV USER_ID=1001 \
     HOME=/home/user/
 
 RUN apk --no-cache upgrade && \
-    apk add --no-cache git git-lfs && \
+    apk add --no-cache bash git git-lfs && \
     git-lfs install --system && \
     mkdir -p /home/user/ && \
     adduser -D $USER_NAME -h $HOME -u $USER_ID


### PR DESCRIPTION
### Description
* Make sure bash is installed in both next and release images (was missing in release image)
* Move installing aws-cli to KServe image where it is needed; the CLI increases image size by ~200MB

### Linked issues
Closes #851 