### PR TITLE
Fix broken SVG image

### DIFF
--- a/docs/.vitepress/config.mts
+++ b/docs/.vitepress/config.mts
@@ -174,7 +174,9 @@ export default defineConfig({
   vite: {
     plugins: [
       tailwindcss(),
-      svgLoader()
+      svgLoader({
+        defaultImport: 'url'
+      })
     ],
     resolve: {
       alias: [


### PR DESCRIPTION
The SVG Loader plugin in the docs site is not passing the url's when svg files are loaded in .md files. This PR fixes that by setting the default svg behavior to be `url` so the `img` tag can reference it.