### PR TITLE
Add `--ignore-existing|-i` flag to kit unpack

### DIFF
--- a/build/dockerfiles/init/entrypoint.sh
+++ b/build/dockerfiles/init/entrypoint.sh
@@ -5,6 +5,7 @@ set -e
 # Kit configuration via env vars:
 #   - UNPACK_PATH   : Where to unpack the modelkit (default: /home/user/modelkit)
 #   - UNPACK_FILTER : What to unpack from the modelkit (default: model)
+#   - EXTRA_FLAGS   : Additional flags for the unpack operation (default: --ignore-existing)
 #   - MODELKIT_REF  : The modelkit to unpack -- required!
 UNPACK_PATH=${UNPACK_PATH:-/home/user/modelkit/}
 UNPACK_FILTER=${UNPACK_FILTER:-model}
@@ -12,6 +13,19 @@ if [ -z "$MODELKIT_REF" ]; then
   echo "Environment variable \$MODELKIT_REF is required"
   exit 1
 fi
+
+read -r -a ADDITIONAL_UNPACK_FLAGS <<< "$EXTRA_FLAGS"
+for flag in "${ADDITIONAL_UNPACK_FLAGS[@]}"; do
+  if [ "$flag" == "--filter" ] || [ "$flag" == "-f" ] || [ "$flag" == "--dir" ] || [ "$flag" == "-d" ]; then
+    echo "Do not use \$EXTRA_FLAGS to specify '--filter' and '--dir' flags"
+    echo "Set environment variables \$UNPACK_PATH and \$UNPACK_FILTER instead"
+    exit 1
+  fi
+done
+if [ ${#ADDITIONAL_UNPACK_FLAGS[@]} == "0" ]; then
+  ADDITIONAL_UNPACK_FLAGS[0]="--ignore-existing"
+fi
+
 
 # Variables for verifying signature via cosign. Can specify either a key to use for
 # verifying or an identity and oidc issuer for keyless verification
@@ -31,5 +45,5 @@ fi
 echo "Binary version info:"
 kit version
 
-echo "Unpacking modelkit $MODELKIT_REF to $UNPACK_PATH with filter $UNPACK_FILTER"
-kit unpack "$MODELKIT_REF" --dir "$UNPACK_PATH" --filter="$UNPACK_FILTER"
+echo "Unpacking modelkit $MODELKIT_REF to $UNPACK_PATH with filter '$UNPACK_FILTER'. Additional flags: ${ADDITIONAL_UNPACK_FLAGS[@]}"
+kit unpack "$MODELKIT_REF" --dir "$UNPACK_PATH" --filter="$UNPACK_FILTER" "${ADDITIONAL_UNPACK_FLAGS[@]}"

--- a/build/dockerfiles/init/entrypoint.sh
+++ b/build/dockerfiles/init/entrypoint.sh
@@ -14,18 +14,16 @@ if [ -z "$MODELKIT_REF" ]; then
   exit 1
 fi
 
+FLAGS_HAS_DIR="false"
 read -r -a ADDITIONAL_UNPACK_FLAGS <<< "$EXTRA_FLAGS"
 for flag in "${ADDITIONAL_UNPACK_FLAGS[@]}"; do
-  if [ "$flag" == "--filter" ] || [ "$flag" == "-f" ] || [ "$flag" == "--dir" ] || [ "$flag" == "-d" ]; then
-    echo "Do not use \$EXTRA_FLAGS to specify '--filter' and '--dir' flags"
-    echo "Set environment variables \$UNPACK_PATH and \$UNPACK_FILTER instead"
-    exit 1
+  if [[ "$flag" == "-d"* ]] || [[ "$flag" == "--dir"* ]]; then
+    FLAGS_HAS_DIR="true"
   fi
 done
 if [ ${#ADDITIONAL_UNPACK_FLAGS[@]} == "0" ]; then
   ADDITIONAL_UNPACK_FLAGS[0]="--ignore-existing"
 fi
-
 
 # Variables for verifying signature via cosign. Can specify either a key to use for
 # verifying or an identity and oidc issuer for keyless verification
@@ -45,5 +43,10 @@ fi
 echo "Binary version info:"
 kit version
 
-echo "Unpacking modelkit $MODELKIT_REF to $UNPACK_PATH with filter '$UNPACK_FILTER'. Additional flags: ${ADDITIONAL_UNPACK_FLAGS[@]}"
-kit unpack "$MODELKIT_REF" --dir "$UNPACK_PATH" --filter="$UNPACK_FILTER" "${ADDITIONAL_UNPACK_FLAGS[@]}"
+if [ "$FLAGS_HAS_DIR" == "false" ]; then
+  echo "Unpacking modelkit $MODELKIT_REF to $UNPACK_PATH with filter '$UNPACK_FILTER'. Additional flags: ${ADDITIONAL_UNPACK_FLAGS[@]}"
+  kit unpack "$MODELKIT_REF" --dir "$UNPACK_PATH" --filter="$UNPACK_FILTER" "${ADDITIONAL_UNPACK_FLAGS[@]}"
+else
+  echo "Unpacking modelkit $MODELKIT_REF with flags '--filter=$UNPACK_FILTER ${ADDITIONAL_UNPACK_FLAGS[@]}'"
+  kit unpack "$MODELKIT_REF" --filter="$UNPACK_FILTER" "${ADDITIONAL_UNPACK_FLAGS[@]}"
+fi

--- a/pkg/cmd/unpack/cmd.go
+++ b/pkg/cmd/unpack/cmd.go
@@ -82,13 +82,14 @@ kit unpack registry.example.com/myrepo/my-model:latest -o -d /path/to/unpacked`
 
 type unpackOptions struct {
 	options.NetworkOptions
-	configHome  string
-	unpackDir   string
-	filters     []string
-	filterConfs []filterConf
-	unpackConf  unpackConf
-	modelRef    *registry.Reference
-	overwrite   bool
+	configHome     string
+	unpackDir      string
+	filters        []string
+	filterConfs    []filterConf
+	unpackConf     unpackConf
+	modelRef       *registry.Reference
+	overwrite      bool
+	ignoreExisting bool
 }
 
 // unpackConf configures which elements of the modelkit should be unpacked.
@@ -160,6 +161,7 @@ func UnpackCommand() *cobra.Command {
 	cmd.Args = cobra.ExactArgs(1)
 	cmd.Flags().StringVarP(&opts.unpackDir, "dir", "d", "", "The target directory to unpack components into. This directory will be created if it does not exist")
 	cmd.Flags().BoolVarP(&opts.overwrite, "overwrite", "o", false, "Overwrites existing files and directories in the target unpack directory without prompting")
+	cmd.Flags().BoolVarP(&opts.ignoreExisting, "ignore-existing", "i", false, "Skip unpacking files if a file with that name already exists")
 	cmd.Flags().StringArrayVarP(&opts.filters, "filter", "f", []string{}, "Filter what is unpacked from the modelkit based on type and name. Can be specified multiple times")
 	cmd.Flags().BoolVar(&opts.unpackConf.unpackKitfile, "kitfile", false, "Unpack only Kitfile (deprecated: use --filter=kitfile)")
 	cmd.Flags().BoolVar(&opts.unpackConf.unpackModels, "model", false, "Unpack only model (deprecated: use --filter=model)")


### PR DESCRIPTION
### Description
Add flag
```
  -i, --ignore-existing      Skip unpacking files if a file with that name already exists
```

to kit unpack. This allows kit unpack to be run idempotently (i.e. only unpacking files that do not currently exist) and is intended for use in e.g. init containers that unpack into persistent volumes.

This commit also changes how existing Kitfiles are processed:

* if the overwrite flag is provided, the existing Kitfile is overwritten as before
* otherwise, we compare the existing Kitfile and do not report and error if the existing Kitfile matches the to-be-unpacked one

Additionally, add support for `$EXTRA_FLAGS` env var in the kit init container, which can be  used to specify arbitrary flags for the unpack command as we do for the KServe container, with the following caveats:

* By default, we use `--ignore-existing` for the init container; this can be disabled by setting some other value for `$EXTRA_FLAGS`
* If `$EXTRA_FLAGS` contains `--filter` or `--dir` flags, we exit with an error

### Linked issues
Closes #874 
