### PR TITLE
Feat(CI): Add SBOM generation to release pipeline

### DIFF
--- a/.github/workflows/platform-release.yaml
+++ b/.github/workflows/platform-release.yaml
@@ -1,6 +1,6 @@
 name: Release with Platform builds
 
-on: 
+on:
   workflow_dispatch:
     inputs:
       skip_signing:
@@ -59,6 +59,11 @@ jobs:
           p12-file-base64: ${{ secrets.APPLE_CERTIFICATE_BASE64 }}
           p12-password: ${{ secrets.APPLE_CERTIFICATE_PASSWORD }}
 
+      - name: Install Syft
+        uses: anchore/sbom-action/download-syft@da167eac915b4e86f08b264dbdbc867b61be6f0c #v0.20.5
+        with:
+          syft-version: v1.32.0
+
       - name: Run GoReleaser
         uses: goreleaser/goreleaser-action@e435ccd777264be153ace6237001ef4d979d3a7a #v6.4.0
         with:
@@ -92,6 +97,7 @@ jobs:
             path: |
               ./dist/*.zip
               ./dist/*.tar.gz
+              ./dist/*.sbom.json
 
   build-windows:
     runs-on: windows-latest
@@ -103,6 +109,11 @@ jobs:
         uses: actions/setup-go@d35c59abb061a4a6fb18e82ac0862c26744d6ab5 # v5.5.0
         with:
             go-version-file: 'go.mod'
+
+      - name: Install Syft
+        uses: anchore/sbom-action/download-syft@da167eac915b4e86f08b264dbdbc867b61be6f0c #v0.20.5
+        with:
+          syft-version: v1.32.0
 
       - name: Run GoReleaser
         uses: goreleaser/goreleaser-action@e435ccd777264be153ace6237001ef4d979d3a7a #v6.4.0
@@ -120,6 +131,7 @@ jobs:
             retention-days: 7
             path: |
               ./dist/*.zip
+              ./dist/*.sbom.json
 
   build-linux:
     runs-on: ubuntu-latest
@@ -131,6 +143,11 @@ jobs:
         uses: actions/setup-go@d35c59abb061a4a6fb18e82ac0862c26744d6ab5 # v5.5.0
         with:
             go-version-file: 'go.mod'
+
+      - name: Install Syft
+        uses: anchore/sbom-action/download-syft@da167eac915b4e86f08b264dbdbc867b61be6f0c #v0.20.5
+        with:
+          syft-version: v1.32.0
 
       - name: Run GoReleaser
         uses: goreleaser/goreleaser-action@e435ccd777264be153ace6237001ef4d979d3a7a #v6.4.0
@@ -149,7 +166,8 @@ jobs:
             retention-days: 7
             path: |
               ./dist/*.tar.gz
-  
+              ./dist/*.sbom.json
+
   # Creates a release using artifacts created in the previous steps.
   # workflow_dispatch triggered versions will be draft releases.
   # CLI docs are not updated for workflow_dispatch triggered versions.
@@ -162,16 +180,16 @@ jobs:
         uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
         with:
           path: kitops
-      
-      # Create the homebrew-file directory to store the 
-      # homebrew artifacts and copy the awk script and 
-      # recipe template to it. These will be used later 
+
+      # Create the homebrew-file directory to store the
+      # homebrew artifacts and copy the awk script and
+      # recipe template to it. These will be used later
       # to build the homebrew recipe file.
       - name: Create homebrew-files dir
         run: |
           mkdir homebrew-files
           cp ./kitops/build/homebrew/*.* ./homebrew-files
-          
+
       - name: Merge build artifacts
         uses: actions/download-artifact@634f93cb2916e3fdff6788551b99b062d0335ce0 # v5.0.0
         with:
@@ -186,14 +204,14 @@ jobs:
         run: |
           shopt -s failglob
           pushd dist
-          shasum -a 256 kitops-* > checksums.txt
+          shasum -a 256 kitops-* | grep -v '.sbom.json$' > checksums.txt
           mv checksums.txt kitops_${TAG_NAME}_checksums.txt
           cp kitops_${TAG_NAME}_checksums.txt ../homebrew-files/.
           popd
 
-      # upload the homebrew-files directory (and its contents) 
+      # upload the homebrew-files directory (and its contents)
       # as an artifact to be used later when generating the
-      # homebrew recipe and pushing it to the repository: 
+      # homebrew recipe and pushing it to the repository:
       # 'kitops-ml/homebrew-kitops'
       - name: Upload homebrew-files as a build artifact
         uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02  # v4.6.2
@@ -242,10 +260,10 @@ jobs:
           git branch "$PR_BRANCH"
           git checkout "$PR_BRANCH"
           git pull origin --ff-only "${PR_BRANCH}" || true
-  
+
           git config --global user.name "${GITHUB_ACTOR}"
           git config --global user.email "${GITHUB_ACTOR_ID}+${GITHUB_ACTOR}@users.noreply.github.com"
-  
+
           (cd docs; npm pkg set version=$TAG_NAME)
           ./docs/src/docs/cli/generate.sh > /dev/null
           git add --all
@@ -268,7 +286,7 @@ jobs:
         with:
           app-id: ${{ vars.KITOPS_BOT_ID }}
           private-key: ${{ secrets.KITOPS_BOT_PRIVATE_KEY }}
-          owner: kitops-ml      
+          owner: kitops-ml
       # checkout the homebrew-kitops repository (kitops-ml/homebrew-kitops)
       - name: Checkout homebrew-kitops
         uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
@@ -277,7 +295,7 @@ jobs:
           ref: 'main'
           path: homebrew-kitops
           token: ${{ steps.generate-token.outputs.token }}
-            
+
       - name: Download the homebrew artifacts to build the homebrew recipe
         uses: actions/download-artifact@634f93cb2916e3fdff6788551b99b062d0335ce0 # v5.0.0
         with:
@@ -294,10 +312,10 @@ jobs:
           pushd homebrew-files
           awk '
             BEGIN { tag_name = ENVIRON["TAG_NAME"]; repo = ENVIRON["REPO"];}
-            /.tar.gz$/ { 
-             print "\""$1"\"", 
-              "\"https://github.com/" repo "/releases/download/" tag_name "/" $2 "\"", 
-              $2, 
+            /.tar.gz$/ {
+             print "\""$1"\"",
+              "\"https://github.com/" repo "/releases/download/" tag_name "/" $2 "\"",
+              $2,
               tag_name }' kitops_${TAG_NAME}_checksums.txt |
           awk '{ sub(/.tar.gz/, "", $3); print $1, $2, $3, $4 }' |
           awk '{ sub(/kitops-/, "", $3); print $1, $2, $3, $4 }' |
@@ -305,7 +323,7 @@ jobs:
           popd
 
       # uses the homebrew-metadata.txt file generated in the
-      # previous step to generate the homebrew formula (kitops.rb) 
+      # previous step to generate the homebrew formula (kitops.rb)
       # for the homebrew tap (located at 'kitops-ml/homebrew-kitops')
       - name: Create homebrew formula
         run: |

--- a/.goreleaser.darwin.yaml
+++ b/.goreleaser.darwin.yaml
@@ -24,7 +24,7 @@ builds:
         - cmd: ./build/scripts/sign '{{ .Path }}'
           output: true
   - id: "kit-macos-offline"
-    flags: 
+    flags:
       - --tags=embed_harness
     env:
       - CGO_ENABLED=0
@@ -43,7 +43,7 @@ builds:
 
 archives:
   # zip archives for Mac OS:
-  #   - will be notorized 
+  #   - will be notorized
   #   - will be made available for users to install manually
   - id: kit-macos-zip-archive
     format: zip
@@ -95,3 +95,6 @@ git:
 snapshot:
   name_template: "{{ .Version }}"
 
+sboms:
+  - id: kit-sbom-darwin
+    artifacts: archive

--- a/.goreleaser.linux.yaml
+++ b/.goreleaser.linux.yaml
@@ -17,7 +17,7 @@ builds:
     ldflags:
       - -s -w -X github.com/kitops-ml/kitops/pkg/lib/constants.Version={{.Version}} -X github.com/kitops-ml/kitops/pkg/lib/constants.GitCommit={{.Commit}} -X github.com/kitops-ml/kitops/pkg/lib/constants.BuildTime={{.CommitDate}}
   - id: "kit-linux-embedded"
-    flags: 
+    flags:
       - --tags=embed_harness
     env:
       - CGO_ENABLED=0
@@ -63,3 +63,7 @@ git:
 
 snapshot:
   name_template: "{{ .Version }}"
+
+sboms:
+  - id: kit-sbom-linux
+    artifacts: archive

--- a/.goreleaser.windows.yaml
+++ b/.goreleaser.windows.yaml
@@ -17,7 +17,7 @@ builds:
     ldflags:
       - -s -w -X github.com/kitops-ml/kitops/pkg/lib/constants.Version={{.Version}} -X github.com/kitops-ml/kitops/pkg/lib/constants.GitCommit={{.Commit}} -X github.com/kitops-ml/kitops/pkg/lib/constants.BuildTime={{.CommitDate}}
   - id: "kit-wins-embedded"
-    flags: 
+    flags:
       - --tags=embed_harness
     env:
       - CGO_ENABLED=0
@@ -59,3 +59,7 @@ archives:
 
 snapshot:
   name_template: "{{ .Version }}"
+
+sboms:
+  - id: kit-sbom-windows
+    artifacts: archive


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request. Please review
* Our contributing guide: https://github.com/kitops-ml/kitops/blob/main/CONTRIBUTING.md
* Our code of conduct: https://github.com/kitops-ml/kitops/blob/main/CODE-OF-CONDUCT.md
-->

### Description
<!-- describe the changes in this PR -->
This PR enhances the Kit CLI release process by automatically generating a Software Bill of Materials (SBOM) for each release.
I have added SBOM generation support using [syft](https://github.com/anchore/sbom-action) and [goreleaser](https://goreleaser.com/customization/sbom/) to create SBOM for release artifacts.
the SBOMs will be published alongside release artifacts in github release page. PTAL [here](https://github.com/bupd/kitops/releases/tag/untagged-b9af146feb5f13bdaf7e)

> ℹ️ Documentation updates about SBOM usage and details will be handled in a separate PR.

### Linked issues
<!-- link any issues in this repository that are related to the PR; use "closes <issue>" or "fixes <issue>" to automatically link issues to this PR -->
Fixes #703 