### PR TITLE
Use correct base image for Go version

### DIFF
--- a/build/dockerfiles/Dockerfile
+++ b/build/dockerfiles/Dockerfile
@@ -1,4 +1,4 @@
-FROM docker.io/library/golang:1.23.7-alpine AS builder
+FROM docker.io/library/golang:1.25-alpine AS builder
 
 RUN apk --no-cache upgrade && apk add --no-cache git
 ARG KIT_VERSION=next


### PR DESCRIPTION
Update Docker file to use same or better go version.