### PR TITLE
Add building container to PR checks

### DIFF
--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -5,7 +5,7 @@ on:
     branches: [ main ]
 
 jobs:
-  go:
+  check-sources:
     name: Check sources
     runs-on: ${{ matrix.os }}
     strategy:
@@ -101,3 +101,25 @@ jobs:
           retention-days: 3
           path: |
             ./kit*
+
+  check-container-build:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@29109295f81e9208d7d86ff1c6c12d2833863392    # v3.6.0
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@e468171a9de216ec08956ac3ada2f0791b6bd435  # v3.11.1
+
+      - name: Checkout
+        uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
+
+      - name: Check kit container build
+        uses: docker/build-push-action@263435318d21b8e681c14492fe198d362a7d2c83    # v6.18.0
+        with:
+          platforms: linux/amd64,linux/arm64
+          push: false
+          context: .
+          file: build/dockerfiles/Dockerfile
+          build-args: |
+            KIT_VERSION=${{ github.ref_name }}


### PR DESCRIPTION
### Description
Add building the container images to the PR check, to avoid failing CI after a merge.

### Linked issues
N/A
