### PR TITLE
Add dynamic shell completions for ModelKit references

### DIFF
--- a/cmd/root.go
+++ b/cmd/root.go
@@ -127,7 +127,13 @@ func RunCommand() *cobra.Command {
 	}
 	addSubcommands(cmd)
 	cmd.PersistentFlags().StringVar(&opts.loglevel, "log-level", "info", "Log messages above specified level ('trace', 'debug', 'info', 'warn', 'error') (default 'info')")
+	cmd.RegisterFlagCompletionFunc("log-level", func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
+		return []string{"trace", "debug", "info", "warn", "error"}, cobra.ShellCompDirectiveDefault
+	})
 	cmd.PersistentFlags().StringVar(&opts.progressBars, "progress", "plain", "Configure progress bars for longer operations (options: none, plain, fancy)")
+	cmd.RegisterFlagCompletionFunc("progress", func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
+		return []string{"none", "plain", "fancy"}, cobra.ShellCompDirectiveDefault
+	})
 	cmd.PersistentFlags().StringVar(&opts.configHome, "config", "", "Alternate path to root storage directory for CLI")
 	cmd.PersistentFlags().CountVarP(&opts.verbosity, "verbose", "v", "Increase verbosity of output (use -vv for more)")
 	cmd.PersistentFlags().SortFlags = false
@@ -138,6 +144,8 @@ func RunCommand() *cobra.Command {
 	cobra.AddTemplateFunc("indent", indentBlock)
 	cobra.AddTemplateFunc("sectionHead", sectionHead)
 	cobra.AddTemplateFunc("ensureTrailingNewline", ensureTrailingNewline)
+
+	cmd.CompletionOptions.SetDefaultShellCompDirective(cobra.ShellCompDirectiveNoFileComp)
 	return cmd
 }
 

--- a/pkg/cmd/info/cmd.go
+++ b/pkg/cmd/info/cmd.go
@@ -27,6 +27,7 @@ import (
 
 	"github.com/kitops-ml/kitops/pkg/artifact"
 	"github.com/kitops-ml/kitops/pkg/cmd/options"
+	"github.com/kitops-ml/kitops/pkg/lib/completion"
 	"github.com/kitops-ml/kitops/pkg/lib/constants"
 	"github.com/kitops-ml/kitops/pkg/lib/repo/util"
 	"github.com/kitops-ml/kitops/pkg/output"
@@ -78,6 +79,15 @@ func InfoCommand() *cobra.Command {
 		Example: example,
 		RunE:    runCommand(opts),
 		Args:    cobra.ExactArgs(1),
+		ValidArgsFunction: func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
+			if cmd.Flags().Changed("remote") {
+				return nil, cobra.ShellCompDirectiveNoFileComp
+			}
+			if len(args) >= 1 {
+				return nil, cobra.ShellCompDirectiveNoFileComp
+			}
+			return completion.GetLocalModelKitsCompletion(cmd.Context(), toComplete), cobra.ShellCompDirectiveNoFileComp | cobra.ShellCompDirectiveNoSpace
+		},
 	}
 
 	opts.AddNetworkFlags(cmd)

--- a/pkg/cmd/inspect/cmd.go
+++ b/pkg/cmd/inspect/cmd.go
@@ -24,6 +24,7 @@ import (
 	"strings"
 
 	"github.com/kitops-ml/kitops/pkg/cmd/options"
+	"github.com/kitops-ml/kitops/pkg/lib/completion"
 	"github.com/kitops-ml/kitops/pkg/lib/constants"
 	"github.com/kitops-ml/kitops/pkg/lib/repo/util"
 	"github.com/kitops-ml/kitops/pkg/output"
@@ -66,6 +67,15 @@ func InspectCommand() *cobra.Command {
 		Example: example,
 		RunE:    runCommand(opts),
 		Args:    cobra.ExactArgs(1),
+		ValidArgsFunction: func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
+			if cmd.Flags().Changed("remote") {
+				return nil, cobra.ShellCompDirectiveNoFileComp
+			}
+			if len(args) >= 1 {
+				return nil, cobra.ShellCompDirectiveNoFileComp
+			}
+			return completion.GetLocalModelKitsCompletion(cmd.Context(), toComplete), cobra.ShellCompDirectiveNoFileComp | cobra.ShellCompDirectiveNoSpace
+		},
 	}
 
 	opts.AddNetworkFlags(cmd)

--- a/pkg/cmd/pack/cmd.go
+++ b/pkg/cmd/pack/cmd.go
@@ -80,6 +80,7 @@ func PackCommand() *cobra.Command {
 	cmd.Flags().StringVar(&opts.compression, "compression", "none", "Compression format to use for layers. Valid options: 'none' (default), 'gzip', 'gzip-fastest'")
 	cmd.Flags().SortFlags = false
 	cmd.Args = cobra.ExactArgs(1)
+	cmd.CompletionOptions.SetDefaultShellCompDirective(cobra.ShellCompDirectiveDefault)
 	return cmd
 }
 

--- a/pkg/cmd/push/cmd.go
+++ b/pkg/cmd/push/cmd.go
@@ -23,6 +23,7 @@ import (
 	"net/http"
 
 	"github.com/kitops-ml/kitops/pkg/cmd/options"
+	"github.com/kitops-ml/kitops/pkg/lib/completion"
 	"github.com/kitops-ml/kitops/pkg/lib/constants"
 	"github.com/kitops-ml/kitops/pkg/lib/repo/local"
 	"github.com/kitops-ml/kitops/pkg/lib/repo/remote"
@@ -105,9 +106,15 @@ func PushCommand() *cobra.Command {
 		Long:    longDesc,
 		Example: example,
 		RunE:    runCommand(opts),
+		Args:    cobra.RangeArgs(1, 2),
+		ValidArgsFunction: func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
+			if len(args) >= 2 {
+				return nil, cobra.ShellCompDirectiveNoFileComp
+			}
+			return completion.GetLocalModelKitsCompletion(cmd.Context(), toComplete), cobra.ShellCompDirectiveNoFileComp | cobra.ShellCompDirectiveNoSpace
+		},
 	}
 
-	cmd.Args = cobra.RangeArgs(1, 2)
 	opts.AddNetworkFlags(cmd)
 	cmd.Flags().SortFlags = false
 

--- a/pkg/cmd/remove/cmd.go
+++ b/pkg/cmd/remove/cmd.go
@@ -22,6 +22,7 @@ import (
 	"strings"
 
 	"github.com/kitops-ml/kitops/pkg/cmd/options"
+	"github.com/kitops-ml/kitops/pkg/lib/completion"
 	"github.com/kitops-ml/kitops/pkg/lib/constants"
 	"github.com/kitops-ml/kitops/pkg/lib/repo/util"
 	"github.com/kitops-ml/kitops/pkg/output"
@@ -102,8 +103,16 @@ func RemoveCommand() *cobra.Command {
 		Long:    longDesc,
 		Example: examples,
 		RunE:    runCommand(opts),
+		ValidArgsFunction: func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
+			if cmd.Flags().Changed("all") || cmd.Flags().Changed("remote") {
+				return nil, cobra.ShellCompDirectiveNoFileComp
+			}
+			if len(args) >= 1 {
+				return nil, cobra.ShellCompDirectiveNoFileComp
+			}
+			return completion.GetLocalModelKitsCompletion(cmd.Context(), toComplete), cobra.ShellCompDirectiveNoFileComp | cobra.ShellCompDirectiveNoSpace
+		},
 	}
-	// cmd.Args = cobra.ExactArgs(1)
 	cmd.Flags().BoolVarP(&opts.forceDelete, "force", "f", false, "remove modelkit and all other tags that refer to it")
 	cmd.Flags().BoolVarP(&opts.removeAll, "all", "a", false, "remove all untagged modelkits")
 	cmd.Flags().BoolVarP(&opts.remote, "remote", "r", false, "remove modelkit from remote registry")

--- a/pkg/cmd/tag/cmd.go
+++ b/pkg/cmd/tag/cmd.go
@@ -20,6 +20,7 @@ import (
 	"context"
 	"fmt"
 
+	"github.com/kitops-ml/kitops/pkg/lib/completion"
 	"github.com/kitops-ml/kitops/pkg/lib/constants"
 	"github.com/kitops-ml/kitops/pkg/lib/repo/util"
 	"github.com/kitops-ml/kitops/pkg/output"
@@ -103,6 +104,12 @@ func TagCommand() *cobra.Command {
 		Long:    longDesc,
 		Example: example,
 		RunE:    runCommand(&tagOptions{}),
+		ValidArgsFunction: func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
+			if len(args) >= 1 {
+				return nil, cobra.ShellCompDirectiveNoFileComp
+			}
+			return completion.GetLocalModelKitsCompletion(cmd.Context(), toComplete), cobra.ShellCompDirectiveNoFileComp | cobra.ShellCompDirectiveNoSpace
+		},
 	}
 
 	cmd.Args = cobra.ExactArgs(2)

--- a/pkg/cmd/unpack/cmd.go
+++ b/pkg/cmd/unpack/cmd.go
@@ -162,6 +162,7 @@ func UnpackCommand() *cobra.Command {
 	opts.AddNetworkFlags(cmd)
 	cmd.Flags().SortFlags = false
 
+	cmd.CompletionOptions.SetDefaultShellCompDirective(cobra.ShellCompDirectiveDefault)
 	return cmd
 }
 

--- a/pkg/cmd/unpack/cmd.go
+++ b/pkg/cmd/unpack/cmd.go
@@ -23,6 +23,7 @@ import (
 	"path/filepath"
 
 	"github.com/kitops-ml/kitops/pkg/cmd/options"
+	"github.com/kitops-ml/kitops/pkg/lib/completion"
 	"github.com/kitops-ml/kitops/pkg/lib/constants"
 	"github.com/kitops-ml/kitops/pkg/lib/repo/util"
 	"github.com/kitops-ml/kitops/pkg/lib/unpack"
@@ -140,6 +141,12 @@ func UnpackCommand() *cobra.Command {
 		Long:    longDesc,
 		Example: example,
 		RunE:    runCommand(opts),
+		ValidArgsFunction: func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
+			if len(args) >= 1 {
+				return nil, cobra.ShellCompDirectiveNoFileComp
+			}
+			return completion.GetLocalModelKitsCompletion(cmd.Context(), toComplete), cobra.ShellCompDirectiveNoFileComp | cobra.ShellCompDirectiveNoSpace
+		},
 	}
 
 	cmd.Args = cobra.ExactArgs(1)

--- a/pkg/lib/completion/modelkits.go
+++ b/pkg/lib/completion/modelkits.go
@@ -1,0 +1,83 @@
+// Copyright 2025 The KitOps Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+package completion
+
+import (
+	"context"
+	"fmt"
+	"strings"
+
+	"github.com/kitops-ml/kitops/pkg/lib/constants"
+	"github.com/kitops-ml/kitops/pkg/lib/repo/local"
+	"github.com/kitops-ml/kitops/pkg/lib/repo/util"
+	"github.com/spf13/cobra"
+)
+
+func GetLocalModelKitsCompletion(ctx context.Context, toComplete string) []string {
+	configHome, ok := ctx.Value(constants.ConfigKey{}).(string)
+	if !ok {
+		cobra.CompErrorln("Failed to get KitOps config directory")
+		return nil
+	}
+	storageRoot := constants.StoragePath(configHome)
+	localRepos, err := local.GetAllLocalRepos(storageRoot)
+	if err != nil {
+		cobra.CompErrorln("Failed to list local ModelKits")
+		return nil
+	}
+	hasColon := strings.Contains(toComplete, ":")
+	hasAt := strings.Contains(toComplete, "@")
+
+	var completions []string
+	for _, repo := range localRepos {
+		repoName := util.FormatRepositoryForDisplay(repo.GetRepoName())
+		tags, digests := getTagsAndDigestsForRepo(repo)
+		switch {
+		// Note: this case _has_ to come first, as digests themselves contain colons
+		case hasAt:
+			for _, digest := range digests {
+				completions = append(completions, fmt.Sprintf("%s@%s", repoName, digest))
+			}
+		case hasColon:
+			for _, tag := range tags {
+				completions = append(completions, fmt.Sprintf("%s:%s", repoName, tag))
+			}
+		default:
+			switch len(tags) {
+			case 0:
+				completions = append(completions, repoName)
+			case 1:
+				completions = append(completions, fmt.Sprintf("%s:%s", repoName, tags[0]))
+			default:
+				completions = append(completions, repoName+":")
+			}
+		}
+	}
+	return completions
+}
+
+func getTagsAndDigestsForRepo(repo local.LocalRepo) ([]string, []string) {
+	manifestDescs := repo.GetAllModels()
+	var tags []string
+	var digests []string
+	for _, desc := range manifestDescs {
+		repoTags := repo.GetTags(desc)
+		tags = append(tags, repoTags...)
+		digests = append(digests, desc.Digest.String())
+	}
+	return tags, digests
+}


### PR DESCRIPTION
### Description
This PR adds dynamic completions for ModelKit references where applicable:

* `kit info`: If the `--remote` flag is not specified, generate ModelKit reference completions
* `kit inspect`: Same as `kit info`
* `kit push`: Generate completions for ModelKit references, supporting both the one-arg and two-arg (`kit push [SOURCE] [TARGET]`) format
* `kit remove`: Generate completions if the `--all` flag is not specified
* `kit tag`: Generate completions for the first argument only; ignore the second argument
* `kit unpack`: Generate completions. Since we can't tell if the intended ModelKit is present locally (since we can unpack from a remote without pulling first), these may be less useful.

For ModelKit completions, we generate completions in two steps:

* If the to-be-completed reference does not contain a colon (`:`), suggest repositories for completion, ignoring tags. 
    * This is done to keep the list of potential completions small
    * If a completion is accepted, we include a colon, allowing for quickly continuing completion to tags
    * If there's only one tag in a repository, we complete the full reference
* Otherwise, include tags for the currently referenced repository.

Additionally, completion based on digests is supported as well. If a ModelKit reference includes an `@` symbol (as used with `@sha256:...`), we suggest digests based on what's in the repo.

We also do not suggest filepath completions for commands that do not work on the local directory -- e.g. for `kit pack` we support autocompleting local directories, but we suppress those completions for `kit push`. 

Finally, this PR adds flag completions for flags that take on a limited set of values:

* `--progress`: Complete to `none`, `plain`, or `fancy`
* `--log-level`: Complete to one of the log level options


### Linked issues
Closes #79 
Supercedes #934 