### PR TITLE
feat: make upload chunk size configurable

### DIFF
--- a/pkg/cmd/push/cmd.go
+++ b/pkg/cmd/push/cmd.go
@@ -49,14 +49,23 @@ kit push registry.example.com/my-org/my-model:latest
 kit push registry.example.com/my-org/my-model@sha256:44136fa355b3678a1146ad16f7e8649e94fb4fc21fe77e8310c060f61caaff8a
 
 # Push local modelkit 'mymodel:1.0.0' to a remote registry
-kit push mymodel:1.0.0 registry.example.com/my-org/my-model:latest`
+kit push mymodel:1.0.0 registry.example.com/my-org/my-model:latest
+
+# Use smaller chunks on a high-latency or unreliable network
+kit push --chunk-size 16 mymodel:1.0.0 registry.example.com/my-org/my-model:latest`
+
+	bytesPerMiB     int64 = 1 << 20
+	minChunkSizeMiB int64 = 16
+	maxChunkSizeMiB int64 = 32
 )
 
 type pushOptions struct {
 	options.NetworkOptions
-	configHome   string
-	srcModelRef  *registry.Reference
-	destModelRef *registry.Reference
+	configHome      string
+	chunkSizeMiB    int64
+	uploadChunkSize int64
+	srcModelRef     *registry.Reference
+	destModelRef    *registry.Reference
 }
 
 func (opts *pushOptions) complete(ctx context.Context, args []string) error {
@@ -98,6 +107,11 @@ func (opts *pushOptions) complete(ctx context.Context, args []string) error {
 	if opts.destModelRef.Registry == "localhost" {
 		return fmt.Errorf("registry is required when pushing")
 	}
+	uploadChunkSize, err := uploadChunkSizeBytes(opts.chunkSizeMiB)
+	if err != nil {
+		return err
+	}
+	opts.uploadChunkSize = uploadChunkSize
 
 	if err := opts.NetworkOptions.Complete(ctx, args); err != nil {
 		return err
@@ -124,6 +138,12 @@ func PushCommand() *cobra.Command {
 	}
 
 	opts.AddNetworkFlags(cmd)
+	cmd.Flags().Int64Var(
+		&opts.chunkSizeMiB,
+		"chunk-size",
+		remote.DefaultUploadChunkSize/bytesPerMiB,
+		"Maximum size of each blob upload chunk in MiB (16-32)",
+	)
 	cmd.Flags().SortFlags = false
 
 	return cmd
@@ -140,6 +160,7 @@ func runCommand(opts *pushOptions) func(*cobra.Command, []string) error {
 			opts.destModelRef.Registry,
 			opts.destModelRef.Repository,
 			&opts.NetworkOptions,
+			remote.WithUploadChunkSize(opts.uploadChunkSize),
 		)
 		if err != nil {
 			return output.Fatalln(err)
@@ -172,3 +193,18 @@ func runCommand(opts *pushOptions) func(*cobra.Command, []string) error {
 		return nil
 	}
 }
+
+func uploadChunkSizeBytes(sizeMiB int64) (int64, error) {
+	if sizeMiB < minChunkSizeMiB || sizeMiB > maxChunkSizeMiB {
+		return 0, fmt.Errorf(
+			"invalid argument for chunk-size (%d): must be between %d and %d MiB",
+			sizeMiB,
+			minChunkSizeMiB,
+			maxChunkSizeMiB,
+		)
+	}
+
+	return sizeMiB * bytesPerMiB, nil
+}
+
+// AGENT_MODIFIED: Human review required before merge

--- a/pkg/cmd/push/cmd_test.go
+++ b/pkg/cmd/push/cmd_test.go
@@ -1,0 +1,55 @@
+// Copyright 2024 The KitOps Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+package push
+
+import (
+	"testing"
+)
+
+func TestPushCommandUploadChunkSizeDefault(t *testing.T) {
+	t.Parallel()
+
+	got, err := PushCommand().Flags().GetInt64("chunk-size")
+	if err != nil {
+		t.Fatalf("get chunk-size flag: %v", err)
+	}
+	if got != 32 {
+		t.Fatalf("chunk-size default = %d MiB, want 32 MiB", got)
+	}
+}
+
+func TestUploadChunkSizeBytes(t *testing.T) {
+	t.Parallel()
+
+	for _, sizeMiB := range []int64{16, 32} {
+		got, err := uploadChunkSizeBytes(sizeMiB)
+		if err != nil {
+			t.Fatalf("uploadChunkSizeBytes(%d): %v", sizeMiB, err)
+		}
+		if want := sizeMiB * bytesPerMiB; got != want {
+			t.Fatalf("uploadChunkSizeBytes(%d) = %d, want %d", sizeMiB, got, want)
+		}
+	}
+
+	for _, sizeMiB := range []int64{-1, 0, 15, 33} {
+		if _, err := uploadChunkSizeBytes(sizeMiB); err == nil {
+			t.Fatalf("uploadChunkSizeBytes(%d) should fail", sizeMiB)
+		}
+	}
+}
+
+// AGENT_MODIFIED: Human review required before merge

--- a/pkg/lib/repo/remote/registry.go
+++ b/pkg/lib/repo/remote/registry.go
@@ -51,8 +51,30 @@ func NewRegistry(hostname string, opts *options.NetworkOptions) (*remote.Registr
 	return reg, nil
 }
 
-func NewRepository(ctx context.Context, hostname, repository string, opts *options.NetworkOptions) (registry.Repository, error) {
-	reg, err := NewRegistry(hostname, opts)
+// RepositoryOption configures a Repository created by NewRepository.
+type RepositoryOption func(*Repository) error
+
+// WithUploadChunkSize sets the maximum size of each chunked blob upload request.
+func WithUploadChunkSize(size int64) RepositoryOption {
+	return func(repo *Repository) error {
+		if size < 1 {
+			return fmt.Errorf("upload chunk size must be at least 1 byte")
+		}
+
+		repo.uploadChunkSize = size
+
+		return nil
+	}
+}
+
+// NewRepository returns a registry repository configured for KitOps operations.
+func NewRepository(
+	ctx context.Context,
+	hostname, repository string,
+	networkOpts *options.NetworkOptions,
+	repositoryOpts ...RepositoryOption,
+) (registry.Repository, error) {
+	reg, err := NewRegistry(hostname, networkOpts)
 	if err != nil {
 		return nil, fmt.Errorf("could not resolve registry: %w", err)
 	}
@@ -65,11 +87,20 @@ func NewRepository(ctx context.Context, hostname, repository string, opts *optio
 		Repository: repository,
 	}
 
-	return &Repository{
+	configuredRepo := &Repository{
 		Repository:      repo,
 		Reference:       ref,
-		PlainHttp:       opts.PlainHTTP,
+		PlainHttp:       networkOpts.PlainHTTP,
 		Client:          reg.Client,
 		uploadChunkSize: uploadChunkDefaultSize,
-	}, nil
+	}
+	for _, repositoryOpt := range repositoryOpts {
+		if err := repositoryOpt(configuredRepo); err != nil {
+			return nil, err
+		}
+	}
+
+	return configuredRepo, nil
 }
+
+// AGENT_MODIFIED: Human review required before merge

--- a/pkg/lib/repo/remote/registry_test.go
+++ b/pkg/lib/repo/remote/registry_test.go
@@ -1,0 +1,37 @@
+// Copyright 2024 The KitOps Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+package remote
+
+import "testing"
+
+func TestWithUploadChunkSize(t *testing.T) {
+	t.Parallel()
+
+	repo := &Repository{uploadChunkSize: DefaultUploadChunkSize}
+	if err := WithUploadChunkSize(16 << 20)(repo); err != nil {
+		t.Fatalf("WithUploadChunkSize(): %v", err)
+	}
+	if repo.uploadChunkSize != 16<<20 {
+		t.Fatalf("uploadChunkSize = %d, want %d", repo.uploadChunkSize, 16<<20)
+	}
+
+	if err := WithUploadChunkSize(0)(repo); err == nil {
+		t.Fatal("WithUploadChunkSize(0) should fail")
+	}
+}
+
+// AGENT_MODIFIED: Human review required before merge

--- a/pkg/lib/repo/remote/repository.go
+++ b/pkg/lib/repo/remote/repository.go
@@ -200,8 +200,8 @@ func (r *Repository) uploadBlobMonolithic(ctx context.Context, location *url.URL
 	return blobLocation.String(), nil
 }
 
-// uploadBlobChunked performs a chunked blob upload as per the distribution spec. The blob is divided into chunks of maximum 100MiB
-// in size and uploaded sequentially through PATCH requests. Once entire blob is uploaded, a PUT request marks the upload as complete.
+// uploadBlobChunked performs a chunked blob upload as per the distribution spec. The blob is divided into configured-size chunks and
+// uploaded sequentially through PATCH requests. Once entire blob is uploaded, a PUT request marks the upload as complete.
 // Note that the distribution spec 1) requires blobs to uploaded in-order, and 2) does not have a way of specifying maximum blob
 // size.
 func (r *Repository) uploadBlobChunked(ctx context.Context, location *url.URL, authHeader string, expected ocispec.Descriptor, content io.Reader) (string, error) {
@@ -492,3 +492,5 @@ func (r *Repository) copyAuth(req *http.Request, authHeader string) {
 		req.Header.Set("Authorization", authHeader)
 	}
 }
+
+// AGENT_MODIFIED: Human review required before merge

--- a/pkg/lib/repo/remote/upload-format.go
+++ b/pkg/lib/repo/remote/upload-format.go
@@ -32,7 +32,9 @@ const (
 )
 
 const (
-	uploadChunkDefaultSize int64 = 100 << 20
+	// DefaultUploadChunkSize is the default maximum size of each chunked blob upload request.
+	DefaultUploadChunkSize int64 = 32 << 20
+	uploadChunkDefaultSize       = DefaultUploadChunkSize
 )
 
 var (
@@ -67,3 +69,5 @@ func getUploadFormat(registry string, size int64, chunkSize int64) uploadFormat 
 		}
 	}
 }
+
+// AGENT_MODIFIED: Human review required before merge


### PR DESCRIPTION
## Summary
- add `kit push --chunk-size` with an allowed range of 16-32 MiB and a 32 MiB default
- pass the selected size through a repository option to chunked blob uploads
- add CLI and repository option tests

## Validation
- `go test ./pkg/cmd/push ./pkg/lib/repo/remote`
- `go vet ./...`
- `go run . push --help`

## Review note
This is a draft because repository instructions require human review of files carrying `AGENT_MODIFIED` markers. A maintainer should review the changes and remove those markers before marking the PR ready.