### PR TITLE
feat: add kit skill command to install agent skill files

### DIFF
--- a/cmd/root.go
+++ b/cmd/root.go
@@ -37,6 +37,7 @@ import (
 	"github.com/kitops-ml/kitops/pkg/cmd/pull"
 	"github.com/kitops-ml/kitops/pkg/cmd/push"
 	"github.com/kitops-ml/kitops/pkg/cmd/remove"
+	"github.com/kitops-ml/kitops/pkg/cmd/skill"
 	"github.com/kitops-ml/kitops/pkg/cmd/tag"
 	"github.com/kitops-ml/kitops/pkg/cmd/unpack"
 	"github.com/kitops-ml/kitops/pkg/cmd/version"
@@ -167,6 +168,7 @@ func addSubcommands(rootCmd *cobra.Command) {
 	rootCmd.AddCommand(diff.DiffCommand())
 	rootCmd.AddCommand(kitimport.ImportCommand())
 	rootCmd.AddCommand(kitcache.CacheCommand())
+	rootCmd.AddCommand(skill.SkillCommand())
 }
 
 // Execute adds all child commands to the root command and sets flags appropriately.

--- a/pkg/cmd/skill/SKILL.md
+++ b/pkg/cmd/skill/SKILL.md
@@ -80,11 +80,13 @@ kit pull registry.io/org/mymodel:v1.0
 ### 5. Unpack — extract contents locally
 
 ```bash
-kit unpack registry.io/org/mymodel:v1.0                # unpack everything to current dir
-kit unpack registry.io/org/mymodel:v1.0 -d ./output   # unpack to specific directory
-kit unpack registry.io/org/mymodel:v1.0 --model        # model weights only
-kit unpack registry.io/org/mymodel:v1.0 --datasets     # datasets only
-kit unpack registry.io/org/mymodel:v1.0 --code         # code only
+kit unpack registry.io/org/mymodel:v1.0                          # unpack everything to current dir
+kit unpack registry.io/org/mymodel:v1.0 -d ./output              # unpack to specific directory
+kit unpack registry.io/org/mymodel:v1.0 --filter=model           # model weights only
+kit unpack registry.io/org/mymodel:v1.0 --filter=datasets        # datasets only
+kit unpack registry.io/org/mymodel:v1.0 --filter=code            # code only
+kit unpack registry.io/org/mymodel:v1.0 --filter=model,datasets  # model and datasets
+kit unpack registry.io/org/mymodel:v1.0 --filter=datasets:my-dataset  # specific dataset by name
 ```
 
 ## Other Commands
@@ -130,11 +132,10 @@ kit pack . -t registry.io/org/mymodel:v1.0 && kit push registry.io/org/mymodel:v
 
 # Pull and unpack only the model weights
 kit pull registry.io/org/mymodel:v1.0
-kit unpack registry.io/org/mymodel:v1.0 --model -d ./weights
+kit unpack registry.io/org/mymodel:v1.0 --filter=model -d ./weights
 
 # Retag and push to a second registry
 kit tag registry.io/org/mymodel:v1.0 other-registry.io/org/mymodel:v1.0
 kit push other-registry.io/org/mymodel:v1.0
 ```
 
-<!-- AGENT_MODIFIED: Human review required before merge -->

--- a/pkg/cmd/skill/SKILL.md
+++ b/pkg/cmd/skill/SKILL.md
@@ -1,0 +1,140 @@
+# KitOps (`kit`) — AI Agent Skill
+
+## Overview
+
+`kit` is the CLI for KitOps — a CNCF tool for packaging, versioning, and sharing AI/ML models
+and agents. It bundles model weights, datasets, code, and configs into a versioned OCI artifact
+called a **ModelKit**, stored in any standard container registry.
+
+## Core Concepts
+
+- **ModelKit**: An immutable, OCI-compatible bundle. Stored in any container registry (Docker Hub,
+  AWS ECR, GitHub Packages, etc.). Every component is protected by SHA-256 digests.
+- **Kitfile**: A YAML manifest (like a Dockerfile) describing what goes into a ModelKit. Lives in
+  your project directory.
+
+## Kitfile Format
+
+```yaml
+manifestVersion: 1.0.0
+
+package:
+  name: my-model
+  version: 1.0.0
+  description: A short description of the model
+  authors:
+    - My Name
+
+model:
+  name: My Model
+  path: ./weights/model.bin   # relative to project root
+  framework: pytorch
+  license: apache-2.0
+
+datasets:
+  - name: training-data
+    path: ./data/train.csv
+    description: Training dataset
+
+code:
+  - path: ./src
+    description: Training and inference code
+
+docs:
+  - path: ./README.md
+```
+
+All `path:` values are relative to the directory containing the Kitfile.
+
+## Core Workflow
+
+### 1. Initialize — generate a Kitfile
+
+```bash
+kit init .                                              # auto-generate from directory contents
+kit init . --name mymodel --desc "My model"            # with name and description
+kit init . --force                                      # overwrite existing Kitfile
+kit init https://huggingface.co/org/model --remote     # generate from HuggingFace repo
+```
+
+### 2. Pack — create a ModelKit locally
+
+```bash
+kit pack .                                              # pack using Kitfile in current dir
+kit pack . -t registry.io/org/mymodel:v1.0             # pack and tag in one step
+kit pack . -f ./path/to/Kitfile -t registry.io/org/mymodel:v1.0  # custom Kitfile location
+```
+
+### 3. Push — upload to a registry
+
+```bash
+kit push registry.io/org/mymodel:v1.0
+```
+
+### 4. Pull — download from a registry
+
+```bash
+kit pull registry.io/org/mymodel:v1.0
+```
+
+### 5. Unpack — extract contents locally
+
+```bash
+kit unpack registry.io/org/mymodel:v1.0                # unpack everything to current dir
+kit unpack registry.io/org/mymodel:v1.0 -d ./output   # unpack to specific directory
+kit unpack registry.io/org/mymodel:v1.0 --model        # model weights only
+kit unpack registry.io/org/mymodel:v1.0 --datasets     # datasets only
+kit unpack registry.io/org/mymodel:v1.0 --code         # code only
+```
+
+## Other Commands
+
+```bash
+# Tag a ModelKit (like docker tag)
+kit tag registry.io/org/mymodel:v1.0 registry.io/org/mymodel:latest
+
+# List locally stored ModelKits
+kit list
+
+# Inspect a ModelKit's Kitfile without downloading all layers
+kit inspect registry.io/org/mymodel:v1.0
+
+# Import directly from HuggingFace into a ModelKit
+kit import huggingface.co/org/model
+
+# Login to a container registry
+kit login registry.io
+
+# Remove a local ModelKit
+kit remove registry.io/org/mymodel:v1.0
+
+# Show this skill file
+kit skill
+```
+
+## Common Errors and Fixes
+
+| Error | Cause | Fix |
+|-------|-------|-----|
+| `Kitfile already exists` | `kit init` when Kitfile is present | Add `--force` to overwrite |
+| `authentication required` | Not logged in to registry | Run `kit login <registry>` first |
+| `failed to resolve reference` | Tag not found locally or remotely | Verify with `kit list` or `kit inspect` |
+| `no such file or directory` during pack | `path:` in Kitfile does not exist | Check all `path:` values are relative to the project root |
+| `manifest unknown` | Tag doesn't exist in remote registry | Verify the tag exists in the registry |
+
+## Reference Patterns
+
+```bash
+# Full pack-and-push pipeline
+kit pack . -t registry.io/org/mymodel:v1.0 && kit push registry.io/org/mymodel:v1.0
+
+# Pull and unpack only the model weights
+kit pull registry.io/org/mymodel:v1.0
+kit unpack registry.io/org/mymodel:v1.0 --model -d ./weights
+
+# Retag and push to a second registry
+kit tag registry.io/org/mymodel:v1.0 other-registry.io/org/mymodel:v1.0
+kit push other-registry.io/org/mymodel:v1.0
+```
+
+<!-- AGENT_MODIFIED: Human review required before merge -->

--- a/pkg/cmd/skill/skill.go
+++ b/pkg/cmd/skill/skill.go
@@ -1,0 +1,139 @@
+// Copyright 2024 The KitOps Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+package skill
+
+import (
+	_ "embed"
+	"errors"
+	"fmt"
+	"io/fs"
+	"os"
+	"path/filepath"
+
+	"github.com/kitops-ml/kitops/pkg/output"
+	"github.com/spf13/cobra"
+)
+
+//go:embed SKILL.md
+var skillContent []byte
+
+const (
+	shortDesc = `Install a skill file to teach AI agents how to use the kit CLI`
+	longDesc  = `The skill command installs a SKILL.md file into AI agent skill directories.
+
+The installed skill teaches the agent about kit workflows, Kitfile authoring,
+pack/push/pull/unpack operations, tagging, and common errors. The skill content
+is embedded in the binary and always matches the installed kit version.
+
+With no flags, the skill content is printed to stdout.`
+
+	example = `# Print the skill content to stdout:
+kit skill
+
+# Install the skill for Claude Code (writes to .claude/skills/kit.md):
+kit skill --agent claude
+
+# Install the skill for a generic agent (writes to .agents/skills/kit.md):
+kit skill --agent generic
+
+# Install the skill to a custom directory:
+kit skill --dir ./my-agent-dir
+
+# Overwrite an existing skill file:
+kit skill --agent claude --force`
+)
+
+var agentDirs = map[string]string{
+	"claude":  filepath.Join(".claude", "skills"),
+	"generic": filepath.Join(".agents", "skills"),
+}
+
+type skillOptions struct {
+	agent string
+	dir   string
+	force bool
+}
+
+func SkillCommand() *cobra.Command {
+	opts := &skillOptions{}
+
+	cmd := &cobra.Command{
+		Use:     "skill",
+		Short:   shortDesc,
+		Long:    longDesc,
+		Example: example,
+		RunE:    runCommand(opts),
+		Args:    cobra.NoArgs,
+	}
+
+	cmd.Flags().StringVar(&opts.agent, "agent", "", "Agent to install skill for (claude, generic)")
+	cmd.RegisterFlagCompletionFunc("agent", func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
+		return []string{"claude", "generic"}, cobra.ShellCompDirectiveDefault
+	})
+	cmd.Flags().StringVar(&opts.dir, "dir", "", "Custom directory to write skill file into")
+	cmd.Flags().BoolVarP(&opts.force, "force", "f", false, "Overwrite existing skill file")
+	cmd.Flags().SortFlags = false
+
+	return cmd
+}
+
+func runCommand(opts *skillOptions) func(*cobra.Command, []string) error {
+	return func(cmd *cobra.Command, args []string) error {
+		if opts.agent != "" && opts.dir != "" {
+			return output.Fatalf("Invalid arguments: --agent and --dir are mutually exclusive")
+		}
+
+		if opts.agent != "" {
+			skillDir, ok := agentDirs[opts.agent]
+			if !ok {
+				return output.Fatalf("Unknown agent %q: supported values are claude, generic", opts.agent)
+			}
+			return writeSkill(skillDir, opts.force)
+		}
+
+		if opts.dir != "" {
+			return writeSkill(opts.dir, opts.force)
+		}
+
+		// No flags: print to stdout
+		fmt.Fprint(cmd.OutOrStdout(), string(skillContent))
+		return nil
+	}
+}
+
+func writeSkill(dir string, force bool) error {
+	if err := os.MkdirAll(dir, 0o755); err != nil {
+		return output.Fatalf("Failed to create directory %s: %s", dir, err)
+	}
+
+	destPath := filepath.Join(dir, "kit.md")
+
+	if _, err := os.Stat(destPath); err == nil {
+		if !force {
+			return output.Fatalf("Skill file already exists at %s. Use '--force' to overwrite", destPath)
+		}
+	} else if !errors.Is(err, fs.ErrNotExist) {
+		return output.Fatalf("Error checking for existing skill file: %s", err)
+	}
+
+	if err := os.WriteFile(destPath, skillContent, 0o644); err != nil {
+		return output.Fatalf("Failed to write skill file to %s: %s", destPath, err)
+	}
+
+	output.Infof("Skill installed to %s", destPath)
+	return nil
+}

--- a/pkg/cmd/skill/skill_test.go
+++ b/pkg/cmd/skill/skill_test.go
@@ -1,0 +1,145 @@
+// Copyright 2024 The KitOps Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+package skill
+
+import (
+	"bytes"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestWriteSkill_CreatesFile(t *testing.T) {
+	dir := t.TempDir()
+	err := writeSkill(dir, false)
+	require.NoError(t, err)
+
+	destPath := filepath.Join(dir, "kit.md")
+	content, err := os.ReadFile(destPath)
+	require.NoError(t, err)
+	assert.Equal(t, skillContent, content)
+}
+
+func TestWriteSkill_CreatesNestedDirs(t *testing.T) {
+	dir := filepath.Join(t.TempDir(), "nested", "skills")
+	err := writeSkill(dir, false)
+	require.NoError(t, err)
+
+	_, err = os.Stat(filepath.Join(dir, "kit.md"))
+	assert.NoError(t, err)
+}
+
+func TestWriteSkill_ErrorsIfFileExists(t *testing.T) {
+	dir := t.TempDir()
+	destPath := filepath.Join(dir, "kit.md")
+	require.NoError(t, os.WriteFile(destPath, []byte("old"), 0o644))
+
+	err := writeSkill(dir, false)
+	assert.Error(t, err)
+
+	// file should be unchanged
+	content, _ := os.ReadFile(destPath)
+	assert.Equal(t, []byte("old"), content)
+}
+
+func TestWriteSkill_ForceOverwrites(t *testing.T) {
+	dir := t.TempDir()
+	destPath := filepath.Join(dir, "kit.md")
+	require.NoError(t, os.WriteFile(destPath, []byte("old"), 0o644))
+
+	err := writeSkill(dir, true)
+	require.NoError(t, err)
+
+	content, _ := os.ReadFile(destPath)
+	assert.Equal(t, skillContent, content)
+}
+
+func TestSkillCommand_NoFlags_PrintsToStdout(t *testing.T) {
+	cmd := SkillCommand()
+	buf := &bytes.Buffer{}
+	cmd.SetOut(buf)
+	cmd.SetErr(buf)
+
+	err := cmd.Execute()
+	require.NoError(t, err)
+	assert.Equal(t, string(skillContent), buf.String())
+}
+
+func TestSkillCommand_MutuallyExclusiveFlags(t *testing.T) {
+	cmd := SkillCommand()
+	buf := &bytes.Buffer{}
+	cmd.SetOut(buf)
+	cmd.SetErr(buf)
+	cmd.SetArgs([]string{"--agent", "claude", "--dir", "./some-dir"})
+
+	err := cmd.Execute()
+	assert.Error(t, err)
+}
+
+func TestSkillCommand_UnknownAgent(t *testing.T) {
+	cmd := SkillCommand()
+	buf := &bytes.Buffer{}
+	cmd.SetOut(buf)
+	cmd.SetErr(buf)
+	cmd.SetArgs([]string{"--agent", "unknown-agent"})
+
+	err := cmd.Execute()
+	assert.Error(t, err)
+}
+
+func TestSkillCommand_AgentFlag_WritesFile(t *testing.T) {
+	dir := t.TempDir()
+
+	// override the claude agent dir to point inside our temp dir
+	original := agentDirs["claude"]
+	agentDirs["claude"] = filepath.Join(dir, ".claude", "skills")
+	defer func() { agentDirs["claude"] = original }()
+
+	cmd := SkillCommand()
+	buf := &bytes.Buffer{}
+	cmd.SetOut(buf)
+	cmd.SetErr(buf)
+	cmd.SetArgs([]string{"--agent", "claude"})
+
+	err := cmd.Execute()
+	require.NoError(t, err)
+
+	destPath := filepath.Join(agentDirs["claude"], "kit.md")
+	content, err := os.ReadFile(destPath)
+	require.NoError(t, err)
+	assert.Equal(t, skillContent, content)
+}
+
+func TestSkillCommand_DirFlag_WritesFile(t *testing.T) {
+	dir := t.TempDir()
+
+	cmd := SkillCommand()
+	buf := &bytes.Buffer{}
+	cmd.SetOut(buf)
+	cmd.SetErr(buf)
+	cmd.SetArgs([]string{"--dir", dir})
+
+	err := cmd.Execute()
+	require.NoError(t, err)
+
+	content, err := os.ReadFile(filepath.Join(dir, "kit.md"))
+	require.NoError(t, err)
+	assert.Equal(t, skillContent, content)
+}


### PR DESCRIPTION
Closes #1249

## Description

A new kit skill command that installs a SKILL.md file into AI agent skill directories, following the [Agent Skills spec](https://agentskills.io).

The skill teaches agents about kit workflows (Kitfile authoring, pack/push/pull/unpack, tagging, common errors), rather than just flags, so agents can reason about kit tasks without needing internet access or stale manual context.

## Usage

```bash
# Print skill content to stdout
kit skill

# Install for Claude Code → .claude/skills/kit.md
kit skill --agent claude

# Install for generic agents → .agents/skills/kit.md
kit skill --agent generic

# Install to a custom directory
kit skill --dir ./my-agent-dir

# Overwrite existing skill file
kit skill --agent claude --force
```

## Implementation

- pkg/cmd/skill/SKILL.md -> skill content embedded in the binary via //go:embed, so it's always version-matched and works offline
- pkg/cmd/skill/skill.go -> cobra command following the existing command pattern in the repo
- cmd/root.go -> registers SkillCommand() in addSubcommands()

## Testing

kit skill                                            # prints to stdout
kit skill --agent claude                 # creates .claude/skills/kit.md
kit skill --agent claude                 # errors: file exists, use --force
kit skill --agent claude --force   # overwrites
kit skill --agent bad  # errors: unknown agent
kit skill --agent claude --dir ./x  # errors: mutually exclusive flags