### PR TITLE
refactor(fs): replace process-wide os.Chdir with explicit base path

### DIFF
--- a/pkg/cmd/kitimport/util.go
+++ b/pkg/cmd/kitimport/util.go
@@ -83,21 +83,6 @@ func readExistingKitfile(kfPath string) (*artifact.KitFile, error) {
 }
 
 func packDirectory(ctx context.Context, configHome, contextDir string, kitfile *artifact.KitFile, ref *registry.Reference) (*ocispec.Descriptor, error) {
-	// Packing requires the working dir to be the context dir so that relative paths are correct in the tarball
-	// On Windows, we need to switch back to the current directory or removing the temporary directory will fail
-	curDir, err := os.Getwd()
-	if err != nil {
-		return nil, fmt.Errorf("failed to get current directory: %w", err)
-	}
-	if err := os.Chdir(contextDir); err != nil {
-		return nil, fmt.Errorf("failed to use context path %s: %w", contextDir, err)
-	}
-	defer func() {
-		if err := os.Chdir(curDir); err != nil {
-			output.Logf(output.LogLevelWarn, "Failed to change directory to %s: %s", curDir, err)
-		}
-	}()
-
 	localRepo, err := local.NewLocalRepo(constants.StoragePath(configHome), ref)
 	if err != nil {
 		return nil, err
@@ -110,6 +95,7 @@ func packDirectory(ctx context.Context, configHome, contextDir string, kitfile *
 		ModelFormat: mediatype.KitFormat,
 		Compression: mediatype.NoneCompression,
 		LayerFormat: mediatype.TarFormat,
+		ContextDir:  contextDir,
 	})
 	if err != nil {
 		return nil, err

--- a/pkg/cmd/pack/cmd.go
+++ b/pkg/cmd/pack/cmd.go
@@ -19,7 +19,6 @@ package pack
 import (
 	"context"
 	"fmt"
-	"os"
 	"path/filepath"
 	"strings"
 
@@ -96,12 +95,6 @@ func runCommand(opts *packOptions) func(cmd *cobra.Command, args []string) error
 			return output.Fatalf("Invalid arguments: %s", err)
 		}
 
-		// Change working directory to context path to make sure relative paths within
-		// tarballs are correct. This is the equivalent of using the -C parameter for tar
-		if err := os.Chdir(opts.contextDir); err != nil {
-			return output.Fatalf("Failed to use context path %s: %s", opts.contextDir, err)
-		}
-
 		err = runPack(cmd.Context(), opts)
 		if err != nil {
 			return output.Fatalf("Failed to pack model kit: %s", err)
@@ -123,6 +116,22 @@ func (opts *packOptions) complete(ctx context.Context, args []string) error {
 			return err
 		}
 		opts.modelFile = foundModel
+	} else if opts.modelFile != "-" && !filepath.IsAbs(opts.modelFile) {
+		if _, exists := filesystem.PathExists(opts.modelFile); exists {
+			absModelFile, err := filepath.Abs(opts.modelFile)
+			if err != nil {
+				return fmt.Errorf("failed to resolve model file path %s: %w", opts.modelFile, err)
+			}
+			opts.modelFile = absModelFile
+		} else if _, exists := filesystem.PathExists(filepath.Join(opts.contextDir, opts.modelFile)); exists {
+			opts.modelFile = filepath.Join(opts.contextDir, opts.modelFile)
+		} else {
+			absModelFile, err := filepath.Abs(opts.modelFile)
+			if err != nil {
+				return fmt.Errorf("failed to resolve model file path %s: %w", opts.modelFile, err)
+			}
+			opts.modelFile = absModelFile
+		}
 	}
 
 	configHome, ok := ctx.Value(constants.ConfigKey{}).(string)

--- a/pkg/cmd/pack/pack.go
+++ b/pkg/cmd/pack/pack.go
@@ -109,6 +109,7 @@ func pack(ctx context.Context, opts *packOptions, kitfile *artifact.KitFile, loc
 		ModelFormat: modelFormat,
 		Compression: compression,
 		LayerFormat: layerFormat,
+		ContextDir:  opts.contextDir,
 	})
 	if err != nil {
 		return nil, err

--- a/pkg/lib/filesystem/local-storage.go
+++ b/pkg/lib/filesystem/local-storage.go
@@ -22,6 +22,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"os"
+	"path/filepath"
 	"strconv"
 	"time"
 
@@ -44,6 +45,7 @@ type SaveModelOptions struct {
 	ModelFormat mediatype.ModelFormat
 	Compression mediatype.CompressionType
 	LayerFormat mediatype.Format
+	ContextDir  string
 }
 
 // Validate checks that the provided set of options is valid (i.e. supported by KitOps and the relevant specs)
@@ -62,6 +64,15 @@ func SaveModel(ctx context.Context, localRepo local.LocalRepo, kitfile *artifact
 	if err := opts.Validate(); err != nil {
 		return nil, err
 	}
+
+	if opts.ContextDir == "" {
+		opts.ContextDir = "."
+	}
+	absContextDir, err := filepath.Abs(opts.ContextDir)
+	if err != nil {
+		return nil, fmt.Errorf("failed to resolve context directory: %w", err)
+	}
+	opts.ContextDir = absContextDir
 
 	layerDescs, diffIDs, err := saveKitfileLayers(ctx, localRepo, kitfile, ignore, opts)
 	if err != nil {
@@ -154,7 +165,7 @@ func saveKitfileLayers(ctx context.Context, localRepo local.LocalRepo, kitfile *
 	if kitfile.Model != nil {
 		if kitfile.Model.Path != "" && !artifact.IsModelKitReference(kitfile.Model.Path) {
 			mediaType := mediatype.New(opts.ModelFormat, mediatype.ModelBaseType, opts.LayerFormat, opts.Compression)
-			layer, layerInfo, err := saveContentLayer(ctx, localRepo, kitfile.Model.Path, mediaType, ignore)
+			layer, layerInfo, err := saveContentLayer(ctx, localRepo, opts.ContextDir, kitfile.Model.Path, mediaType, ignore)
 			if err != nil {
 				return nil, nil, err
 			}
@@ -164,7 +175,7 @@ func saveKitfileLayers(ctx context.Context, localRepo local.LocalRepo, kitfile *
 		}
 		for idx, part := range kitfile.Model.Parts {
 			mediaType := mediatype.New(opts.ModelFormat, mediatype.ModelPartBaseType, opts.LayerFormat, opts.Compression)
-			layer, layerInfo, err := saveContentLayer(ctx, localRepo, part.Path, mediaType, ignore)
+			layer, layerInfo, err := saveContentLayer(ctx, localRepo, opts.ContextDir, part.Path, mediaType, ignore)
 			if err != nil {
 				return nil, nil, err
 			}
@@ -175,7 +186,7 @@ func saveKitfileLayers(ctx context.Context, localRepo local.LocalRepo, kitfile *
 	}
 	for idx, code := range kitfile.Code {
 		mediaType := mediatype.New(opts.ModelFormat, mediatype.CodeBaseType, opts.LayerFormat, opts.Compression)
-		layer, layerInfo, err := saveContentLayer(ctx, localRepo, code.Path, mediaType, ignore)
+		layer, layerInfo, err := saveContentLayer(ctx, localRepo, opts.ContextDir, code.Path, mediaType, ignore)
 		if err != nil {
 			return nil, nil, err
 		}
@@ -199,7 +210,7 @@ func saveKitfileLayers(ctx context.Context, localRepo local.LocalRepo, kitfile *
 
 		// Otherwise, pack a locally-stored dataset
 		mediaType := mediatype.New(opts.ModelFormat, mediatype.DatasetBaseType, opts.LayerFormat, opts.Compression)
-		layer, layerInfo, err := saveContentLayer(ctx, localRepo, dataset.Path, mediaType, ignore)
+		layer, layerInfo, err := saveContentLayer(ctx, localRepo, opts.ContextDir, dataset.Path, mediaType, ignore)
 		if err != nil {
 			return nil, nil, err
 		}
@@ -209,7 +220,7 @@ func saveKitfileLayers(ctx context.Context, localRepo local.LocalRepo, kitfile *
 	}
 	for idx, docs := range kitfile.Docs {
 		mediaType := mediatype.New(opts.ModelFormat, mediatype.DocsBaseType, opts.LayerFormat, opts.Compression)
-		layer, layerInfo, err := saveContentLayer(ctx, localRepo, docs.Path, mediaType, ignore)
+		layer, layerInfo, err := saveContentLayer(ctx, localRepo, opts.ContextDir, docs.Path, mediaType, ignore)
 		if err != nil {
 			return nil, nil, err
 		}
@@ -220,7 +231,7 @@ func saveKitfileLayers(ctx context.Context, localRepo local.LocalRepo, kitfile *
 	for idx, prompt := range kitfile.Prompts {
 		// Prompt layers are saved as `code` layers with an annotation to distinguish them
 		mediaType := mediatype.New(opts.ModelFormat, mediatype.CodeBaseType, opts.LayerFormat, opts.Compression)
-		layer, layerInfo, err := saveContentLayer(ctx, localRepo, prompt.Path, mediaType, ignore)
+		layer, layerInfo, err := saveContentLayer(ctx, localRepo, opts.ContextDir, prompt.Path, mediaType, ignore)
 		if err != nil {
 			return nil, nil, err
 		}
@@ -239,11 +250,15 @@ func saveKitfileLayers(ctx context.Context, localRepo local.LocalRepo, kitfile *
 	for idx, server := range kitfile.MCPServers {
 		// MCP Bundles are stored as raw, uncompressed layers so that the .mcpb ZIP archive
 		// round-trips byte-for-byte. Validate it is a well-formed bundle before packing.
-		if err := ValidateMCPB(server.Path); err != nil {
+		mcpbPath := server.Path
+		if !filepath.IsAbs(mcpbPath) {
+			mcpbPath = filepath.Join(opts.ContextDir, server.Path)
+		}
+		if err := ValidateMCPB(mcpbPath); err != nil {
 			return nil, nil, fmt.Errorf("invalid MCP bundle for mcpServer %s: %w", server.Name, err)
 		}
 		mediaType := mediatype.New(mediatype.KitFormat, mediatype.MCPBBaseType, mediatype.RawFormat, mediatype.NoneCompression)
-		layer, layerInfo, err := saveContentLayer(ctx, localRepo, server.Path, mediaType, ignore)
+		layer, layerInfo, err := saveContentLayer(ctx, localRepo, opts.ContextDir, server.Path, mediaType, ignore)
 		if err != nil {
 			return nil, nil, err
 		}
@@ -269,12 +284,12 @@ func saveKitfileLayers(ctx context.Context, localRepo local.LocalRepo, kitfile *
 	return layers, diffIDs, nil
 }
 
-func saveContentLayer(ctx context.Context, localRepo local.LocalRepo, path string, mediaType mediatype.MediaType, ignore ignore.Paths) (ocispec.Descriptor, *artifact.LayerInfo, error) {
+func saveContentLayer(ctx context.Context, localRepo local.LocalRepo, contextDir, path string, mediaType mediatype.MediaType, ignore ignore.Paths) (ocispec.Descriptor, *artifact.LayerInfo, error) {
 	switch mediaType.Format() {
 	case mediatype.TarFormat:
-		return saveContentLayerAsTar(ctx, localRepo, path, mediaType, ignore)
+		return saveContentLayerAsTar(ctx, localRepo, contextDir, path, mediaType, ignore)
 	case mediatype.RawFormat:
-		return saveContentLayerAsRaw(ctx, localRepo, path, mediaType, ignore)
+		return saveContentLayerAsRaw(ctx, localRepo, contextDir, path, mediaType, ignore)
 	default:
 		return ocispec.DescriptorEmptyJSON, nil, fmt.Errorf("unknown layer format")
 	}

--- a/pkg/lib/filesystem/paths.go
+++ b/pkg/lib/filesystem/paths.go
@@ -101,8 +101,19 @@ func FindKitfileInPath(contextDir string) (string, error) {
 }
 
 // Return the total size of all files in a basepath, given a set of ignores
-func getTotalSize(basePath string, ignore ignore.Paths) (int64, error) {
-	pathInfo, err := os.Stat(basePath)
+func getTotalSize(contextDir, basePath string, ignore ignore.Paths) (int64, error) {
+	absBasePath := basePath
+	if !filepath.IsAbs(absBasePath) {
+		absBasePath = filepath.Join(contextDir, basePath)
+	}
+	relBasePath := basePath
+	if filepath.IsAbs(relBasePath) {
+		if rel, err := filepath.Rel(contextDir, relBasePath); err == nil {
+			relBasePath = rel
+		}
+	}
+
+	pathInfo, err := os.Stat(absBasePath)
 	if err != nil {
 		if errors.Is(err, os.ErrNotExist) {
 			return 0, fmt.Errorf("path %s does not exist", basePath)
@@ -114,12 +125,16 @@ func getTotalSize(basePath string, ignore ignore.Paths) (int64, error) {
 		return pathInfo.Size(), nil
 	} else if pathInfo.IsDir() {
 		var total int64
-		err := filepath.WalkDir(basePath, func(file string, d fs.DirEntry, err error) error {
+		err := filepath.WalkDir(absBasePath, func(file string, d fs.DirEntry, err error) error {
 			if err != nil {
 				return err
 			}
-			if shouldIgnore, err := ignore.Matches(file, basePath); err != nil {
-				return fmt.Errorf("failed to match %s against ignore file: %w", file, err)
+			relFile, err := filepath.Rel(contextDir, file)
+			if err != nil {
+				return fmt.Errorf("failed to get relative path for %s: %w", file, err)
+			}
+			if shouldIgnore, err := ignore.Matches(relFile, relBasePath); err != nil {
+				return fmt.Errorf("failed to match %s against ignore file: %w", relFile, err)
 			} else if shouldIgnore {
 				if !ignore.HasExclusions() && d.IsDir() {
 					return filepath.SkipDir

--- a/pkg/lib/filesystem/raw.go
+++ b/pkg/lib/filesystem/raw.go
@@ -35,10 +35,21 @@ import (
 	ocispec "github.com/opencontainers/image-spec/specs-go/v1"
 )
 
-func saveContentLayerAsRaw(ctx context.Context, localRepo local.LocalRepo, targetPath string, mediaType mediatype.MediaType, ignore ignore.Paths) (ocispec.Descriptor, *artifact.LayerInfo, error) {
-	targetPath = filepath.Clean(targetPath)
+func saveContentLayerAsRaw(ctx context.Context, localRepo local.LocalRepo, contextDir, targetPath string, mediaType mediatype.MediaType, ignore ignore.Paths) (ocispec.Descriptor, *artifact.LayerInfo, error) {
+	relPath := targetPath
+	if filepath.IsAbs(relPath) {
+		if rel, err := filepath.Rel(contextDir, relPath); err == nil {
+			relPath = rel
+		}
+	}
+	relPath = filepath.Clean(relPath)
 
-	fi, err := os.Lstat(targetPath)
+	absPath := targetPath
+	if !filepath.IsAbs(absPath) {
+		absPath = filepath.Join(contextDir, targetPath)
+	}
+
+	fi, err := os.Lstat(absPath)
 	if err != nil {
 		return ocispec.DescriptorEmptyJSON, nil, fmt.Errorf("failed to read file %s: %w", targetPath, err)
 	}
@@ -93,7 +104,7 @@ func saveContentLayerAsRaw(ctx context.Context, localRepo local.LocalRepo, targe
 		return ocispec.DescriptorEmptyJSON, nil, fmt.Errorf("unsupported compression format: %s", mediaType.Compression())
 	}
 
-	f, err := os.Open(targetPath)
+	f, err := os.Open(absPath)
 	if err != nil {
 		_ = closeAll(toClose)
 		return ocispec.DescriptorEmptyJSON, nil, fmt.Errorf("failed to open file %s: %w", targetPath, err)
@@ -125,7 +136,7 @@ func saveContentLayerAsRaw(ctx context.Context, localRepo local.LocalRepo, targe
 		Digest:    digester.Digest(),
 		Size:      tempFileInfo.Size(),
 	}
-	if err := fillDescAnnotations(&desc, targetPath, fi); err != nil {
+	if err := fillDescAnnotations(&desc, relPath, fi); err != nil {
 		return ocispec.DescriptorEmptyJSON, nil, err
 	}
 	layerInfo := &artifact.LayerInfo{

--- a/pkg/lib/filesystem/tar.go
+++ b/pkg/lib/filesystem/tar.go
@@ -40,11 +40,11 @@ import (
 	ocispec "github.com/opencontainers/image-spec/specs-go/v1"
 )
 
-func saveContentLayerAsTar(ctx context.Context, localRepo local.LocalRepo, path string, mediaType mediatype.MediaType, ignore ignore.Paths) (ocispec.Descriptor, *artifact.LayerInfo, error) {
+func saveContentLayerAsTar(ctx context.Context, localRepo local.LocalRepo, contextDir, path string, mediaType mediatype.MediaType, ignore ignore.Paths) (ocispec.Descriptor, *artifact.LayerInfo, error) {
 	// We want to store a gzipped tar file in store, but to do so we need a descriptor, so we have to compress
 	// to a temporary file. Ideally, we can also add this to the internal store by moving the file to avoid
 	// copying if possible.
-	tempPath, desc, info, err := packLayerToTar(path, mediaType, ignore)
+	tempPath, desc, info, err := packLayerToTar(contextDir, path, mediaType, ignore)
 	if err != nil {
 		return ocispec.DescriptorEmptyJSON, nil, err
 	}
@@ -66,7 +66,7 @@ func saveContentLayerAsTar(ctx context.Context, localRepo local.LocalRepo, path 
 // a descriptor (including hash) for the compressed file, the layer is saved to a temporary file
 // on disk and must be moved to an appropriate location. It is the responsibility of the caller
 // to clean up the temporary file when it is no longer needed.
-func packLayerToTar(path string, mediaType mediatype.MediaType, ignore ignore.Paths) (tempFilePath string, desc ocispec.Descriptor, layerInfo *artifact.LayerInfo, err error) {
+func packLayerToTar(contextDir, path string, mediaType mediatype.MediaType, ignore ignore.Paths) (tempFilePath string, desc ocispec.Descriptor, layerInfo *artifact.LayerInfo, err error) {
 	// Clean path to ensure consistent format (./path vs path/ vs path)
 	path = filepath.Clean(path)
 
@@ -76,7 +76,7 @@ func packLayerToTar(path string, mediaType mediatype.MediaType, ignore ignore.Pa
 		output.Errorf("Warning: %s layer path %s ignored by kitignore", mediaType.UserString(), path)
 	}
 
-	totalSize, err := getTotalSize(path, ignore)
+	totalSize, err := getTotalSize(contextDir, path, ignore)
 	if err != nil {
 		return "", ocispec.DescriptorEmptyJSON, nil, fmt.Errorf("error processing %s: %w", mediaType.UserString(), err)
 	}
@@ -143,7 +143,7 @@ func packLayerToTar(path string, mediaType mediatype.MediaType, ignore ignore.Pa
 		return "", ocispec.DescriptorEmptyJSON, nil, fmt.Errorf("unsupported compression format: %s", mediaType.Compression())
 	}
 
-	if err := writeLayerToTar(path, ignore, pWriter, pLog); err != nil {
+	if err := writeLayerToTar(contextDir, path, ignore, pWriter, pLog); err != nil {
 		// Don't care about these errors since we'll be deleting the file anyways
 		_ = closeAll(toClose)
 		tempFileCleanup()
@@ -178,9 +178,20 @@ func packLayerToTar(path string, mediaType mediatype.MediaType, ignore ignore.Pa
 	return tempFileName, desc, layerInfo, nil
 }
 
-func writeLayerToTar(basePath string, ignorePaths ignore.Paths, tarWriter *output.ProgressTar, plog *output.ProgressLogger) error {
+func writeLayerToTar(contextDir, basePath string, ignorePaths ignore.Paths, tarWriter *output.ProgressTar, plog *output.ProgressLogger) error {
+	absBasePath := basePath
+	if !filepath.IsAbs(absBasePath) {
+		absBasePath = filepath.Join(contextDir, basePath)
+	}
+	relBasePath := basePath
+	if filepath.IsAbs(relBasePath) {
+		if rel, err := filepath.Rel(contextDir, relBasePath); err == nil {
+			relBasePath = rel
+		}
+	}
+
 	// Make sure target path exists; otherwise we'll miss it while walking below
-	_, err := os.Stat(basePath)
+	_, err := os.Stat(absBasePath)
 	if err != nil {
 		if errors.Is(err, os.ErrNotExist) {
 			return fmt.Errorf("path %s does not exist", basePath)
@@ -202,15 +213,15 @@ func writeLayerToTar(basePath string, ignorePaths ignore.Paths, tarWriter *outpu
 		return true
 	}
 
-	err = filepath.Walk(".", func(file string, fi os.FileInfo, err error) error {
+	err = filepath.Walk(contextDir, func(file string, fi os.FileInfo, err error) error {
 		if err != nil {
 			return err
 		}
-		if file == "." {
+		if file == contextDir {
 			return nil
 		}
 		// Since we're walking from the context directory, we want to skip irrelevant files (e.g. sibling directories)
-		if !sameDirTree(basePath, file) {
+		if !sameDirTree(absBasePath, file) {
 			if fi.IsDir() {
 				return filepath.SkipDir
 			}
@@ -234,19 +245,24 @@ func writeLayerToTar(basePath string, ignorePaths ignore.Paths, tarWriter *outpu
 			return nil
 		}
 
+		relFile, err := filepath.Rel(contextDir, file)
+		if err != nil {
+			return fmt.Errorf("failed to get relative path for %s: %w", file, err)
+		}
+
 		// Check if file should be ignored by the ignorefile/other Kitfile layers
-		if shouldIgnore, err := ignorePaths.Matches(file, basePath); err != nil {
-			return fmt.Errorf("failed to match %s against ignore file: %w", file, err)
+		if shouldIgnore, err := ignorePaths.Matches(relFile, relBasePath); err != nil {
+			return fmt.Errorf("failed to match %s against ignore file: %w", relFile, err)
 		} else if shouldIgnore {
 			if !ignorePaths.HasExclusions() && fi.IsDir() {
-				plog.Debugf("Skipping directory %s: ignored", file)
+				plog.Debugf("Skipping directory %s: ignored", relFile)
 				return filepath.SkipDir
 			}
-			plog.Debugf("Skipping file %s: ignored", file)
+			plog.Debugf("Skipping file %s: ignored", relFile)
 			return nil
 		}
 
-		if err := writeHeaderToTar(file, fi, tarWriter, plog); err != nil {
+		if err := writeHeaderToTar(relFile, fi, tarWriter, plog); err != nil {
 			return err
 		}
 		if fi.IsDir() {

--- a/pkg/lib/filesystem/unpack/core.go
+++ b/pkg/lib/filesystem/unpack/core.go
@@ -51,26 +51,16 @@ func UnpackModelKit(ctx context.Context, opts *UnpackOptions) error {
 	if opts == nil {
 		return fmt.Errorf("unpack options must not be nil")
 	}
-	// If an unpack directory is provided, temporarily change the working directory
-	// so that unpack operations that are relative to CWD behave as expected.
-	// This centralizes tar -C semantics inside the unpack library.
-	if opts.UnpackDir != "" {
-		// Ensure the directory exists
-		if err := os.MkdirAll(opts.UnpackDir, 0o755); err != nil {
-			return fmt.Errorf("failed to create unpack directory %s: %w", opts.UnpackDir, err)
-		}
-		originalWd, err := os.Getwd()
-		if err != nil {
-			return fmt.Errorf("failed to get current working directory: %w", err)
-		}
-		if err := os.Chdir(opts.UnpackDir); err != nil {
-			return fmt.Errorf("failed to change working directory to %s: %w", opts.UnpackDir, err)
-		}
-		defer func() {
-			if err := os.Chdir(originalWd); err != nil {
-				output.Debugf("Failed to restore working directory: %v", err)
-			}
-		}()
+	if opts.UnpackDir == "" {
+		opts.UnpackDir = "."
+	}
+	absUnpackDir, err := filepath.Abs(opts.UnpackDir)
+	if err != nil {
+		return fmt.Errorf("failed to resolve unpack directory %s: %w", opts.UnpackDir, err)
+	}
+	opts.UnpackDir = absUnpackDir
+	if err := os.MkdirAll(opts.UnpackDir, 0o755); err != nil {
+		return fmt.Errorf("failed to create unpack directory %s: %w", opts.UnpackDir, err)
 	}
 	if opts.SkillOptions != nil {
 		return unpackSkill(ctx, opts)
@@ -133,7 +123,7 @@ func unpackRecursive(ctx context.Context, opts *UnpackOptions, visitedRefs []str
 	}
 	for _, step := range steps {
 		output.Infoln(step.userMessage)
-		if err := unpackLayer(ctx, store, step.desc, "", opts.Overwrite, opts.IgnoreExisting, step.mediatype); err != nil {
+		if err := unpackLayer(ctx, store, step.desc, opts.UnpackDir, "", opts.Overwrite, opts.IgnoreExisting, step.mediatype); err != nil {
 			return fmt.Errorf("failed to unpack: %w", err)
 		}
 	}
@@ -194,13 +184,13 @@ func handleRemoteData(ctx context.Context, config *artifact.KitFile, opts *Unpac
 			return err
 		}
 		for path, s3Ref := range remoteS3Datasets {
-			_, relPath, err := filesystem.VerifySubpath(opts.UnpackDir, path)
+			targetPath, _, err := filesystem.VerifySubpath(opts.UnpackDir, path)
 			if err != nil {
 				return fmt.Errorf("error verifying path %s for remote reference: %w", path, err)
 			}
 
 			output.Debugf("Downloading remote dataset: Bucket: %s, Key: %s", s3Ref.Bucket, s3Ref.Key)
-			if fi, exists := filesystem.PathExists(relPath); exists {
+			if fi, exists := filesystem.PathExists(targetPath); exists {
 				if opts.IgnoreExisting {
 					output.Debugf("File %s already exists; skipping", path)
 					continue
@@ -213,11 +203,11 @@ func handleRemoteData(ctx context.Context, config *artifact.KitFile, opts *Unpac
 				}
 			}
 
-			pathDir := filepath.Dir(relPath)
+			pathDir := filepath.Dir(targetPath)
 			if err := os.MkdirAll(pathDir, 0755); err != nil {
 				return fmt.Errorf("failed to create directory %s: %w", pathDir, err)
 			}
-			if err := s3api.DownloadObject(ctx, client, &s3Ref, relPath); err != nil {
+			if err := s3api.DownloadObject(ctx, client, &s3Ref, targetPath); err != nil {
 				return fmt.Errorf("failed to download remote dataset for path %s: %w", path, err)
 			}
 			output.Infof("Downloaded remote S3 dataset for path %s", path)
@@ -271,18 +261,6 @@ func unpackRemote(ctx context.Context, ref *registry.Reference, basePath string,
 		if err := os.MkdirAll(targetDir, 0o755); err != nil {
 			return fmt.Errorf("failed to create directory %s: %w", targetDir, err)
 		}
-		originalWd, err := os.Getwd()
-		if err != nil {
-			return fmt.Errorf("failed to get current working directory: %w", err)
-		}
-		if err := os.Chdir(targetDir); err != nil {
-			return fmt.Errorf("failed to change working directory to %s: %w", targetDir, err)
-		}
-		defer func() {
-			if err := os.Chdir(originalWd); err != nil {
-				output.Logf(output.LogLevelWarn, "Failed to restore working directory after unpacking reference ModelKit: %v", err)
-			}
-		}()
 		opts.UnpackDir = targetDir
 	}
 
@@ -323,7 +301,7 @@ func unpackConfig(config *artifact.KitFile, unpackDir string, overwrite bool) er
 	return nil
 }
 
-func unpackLayer(ctx context.Context, store oras.ReadOnlyTarget, desc ocispec.Descriptor, unpackPath string, overwrite, ignoreExisting bool, mt mediatype.MediaType) error {
+func unpackLayer(ctx context.Context, store oras.ReadOnlyTarget, desc ocispec.Descriptor, unpackDir, unpackPath string, overwrite, ignoreExisting bool, mt mediatype.MediaType) error {
 	rc, err := store.Fetch(ctx, desc)
 	if err != nil {
 		return fmt.Errorf("failed get layer %s: %w", desc.Digest, err)
@@ -359,19 +337,20 @@ func unpackLayer(ctx context.Context, store oras.ReadOnlyTarget, desc ocispec.De
 	case mediatype.TarFormat:
 		// Legacy behaviour for ModelKits created prior to Kit v0.5.0 -- tar layers might not include
 		// all parent directories and so these need to be created. For newer ModelKits, unpackPath is empty.
+		extractDir := unpackDir
 		if unpackPath != "" {
-			unpackPath = filepath.Dir(unpackPath)
-			if err := os.MkdirAll(unpackPath, 0755); err != nil {
-				return fmt.Errorf("failed to create directory %s: %w", unpackPath, err)
+			extractDir = filepath.Join(unpackDir, filepath.Dir(unpackPath))
+			if err := os.MkdirAll(extractDir, 0755); err != nil {
+				return fmt.Errorf("failed to create directory %s: %w", extractDir, err)
 			}
 		}
 
 		tr := tar.NewReader(cr)
-		if err := extractTar(tr, unpackPath, overwrite, ignoreExisting, logger); err != nil {
+		if err := extractTar(tr, extractDir, overwrite, ignoreExisting, logger); err != nil {
 			return err
 		}
 	case mediatype.RawFormat:
-		if err := extractRawLayer(cr, desc, overwrite, ignoreExisting, logger); err != nil {
+		if err := extractRawLayer(cr, desc, unpackDir, overwrite, ignoreExisting, logger); err != nil {
 			return err
 		}
 	default:
@@ -391,14 +370,10 @@ func extractTar(tr *tar.Reader, extractDir string, overwrite, ignoreExisting boo
 		if err != nil {
 			return err
 		}
-		outPath := header.Name
-		if extractDir != "" {
-			outPath = filepath.Join(extractDir, header.Name)
-		}
 		// Check if the outPath is within the target directory
-		_, _, err = filesystem.VerifySubpath(extractDir, outPath)
+		outPath, _, err := filesystem.VerifySubpath(extractDir, header.Name)
 		if err != nil {
-			return fmt.Errorf("illegal file path: %s: %w", outPath, err)
+			return fmt.Errorf("illegal file path: %s: %w", header.Name, err)
 		}
 
 		switch header.Typeflag {
@@ -428,6 +403,9 @@ func extractTar(tr *tar.Reader, extractDir string, overwrite, ignoreExisting boo
 				}
 			}
 			logger.Debugf("Unpacking file %s", outPath)
+			if err := os.MkdirAll(filepath.Dir(outPath), 0755); err != nil {
+				return fmt.Errorf("failed to create directory %s: %w", filepath.Dir(outPath), err)
+			}
 			file, err := os.OpenFile(outPath, os.O_CREATE|os.O_TRUNC|os.O_RDWR, header.FileInfo().Mode()&fs.ModePerm)
 			if err != nil {
 				return fmt.Errorf("failed to create file %s: %w", outPath, err)
@@ -450,14 +428,15 @@ func extractTar(tr *tar.Reader, extractDir string, overwrite, ignoreExisting boo
 	return nil
 }
 
-func extractRawLayer(r io.Reader, desc ocispec.Descriptor, overwrite, ignoreExisting bool, logger *output.ProgressLogger) (err error) {
+func extractRawLayer(r io.Reader, desc ocispec.Descriptor, extractDir string, overwrite, ignoreExisting bool, logger *output.ProgressLogger) (err error) {
 	targetPath := desc.Annotations[modelspecv1.AnnotationFilepath]
 	if targetPath == "" {
 		return fmt.Errorf("failed to unpack raw layer: no %s annotation", modelspecv1.AnnotationFilepath)
 	}
 	targetPath = filepath.Clean(targetPath)
 
-	if _, _, err := filesystem.VerifySubpath("", targetPath); err != nil {
+	outPath, _, err := filesystem.VerifySubpath(extractDir, targetPath)
+	if err != nil {
 		return fmt.Errorf("illegal file path: %s: %w", targetPath, err)
 	}
 
@@ -472,7 +451,7 @@ func extractRawLayer(r io.Reader, desc ocispec.Descriptor, overwrite, ignoreExis
 		output.Debugf("no %s annotation on manifest, using defaults", modelspecv1.AnnotationFileMetadata)
 	}
 
-	if fi, exists := filesystem.PathExists(targetPath); exists {
+	if fi, exists := filesystem.PathExists(outPath); exists {
 		if ignoreExisting {
 			output.Debugf("File %s already exists; skipping", targetPath)
 			return
@@ -485,7 +464,7 @@ func extractRawLayer(r io.Reader, desc ocispec.Descriptor, overwrite, ignoreExis
 		}
 	}
 
-	dir := filepath.Dir(targetPath)
+	dir := filepath.Dir(outPath)
 	if dir != "." {
 		if err := os.MkdirAll(dir, 0755); err != nil {
 			return fmt.Errorf("failed to create directories for raw layer: %w", err)
@@ -497,7 +476,7 @@ func extractRawLayer(r io.Reader, desc ocispec.Descriptor, overwrite, ignoreExis
 		fileMode = fs.FileMode(fileMeta.Mode) & fs.ModePerm
 	}
 	logger.Debugf("Unpacking file %s", targetPath)
-	file, err := os.OpenFile(targetPath, os.O_CREATE|os.O_TRUNC|os.O_RDWR, fileMode)
+	file, err := os.OpenFile(outPath, os.O_CREATE|os.O_TRUNC|os.O_RDWR, fileMode)
 	if err != nil {
 		return fmt.Errorf("failed to create file %s: %w", targetPath, err)
 	}

--- a/pkg/lib/filesystem/unpack/legacy.go
+++ b/pkg/lib/filesystem/unpack/legacy.go
@@ -158,7 +158,7 @@ func legacyUnpackLayers(ctx context.Context, store oras.ReadOnlyTarget, manifest
 			}
 		}
 
-		if err := unpackLayer(ctx, store, layerDesc, relPath, opts.Overwrite, opts.IgnoreExisting, mediaType); err != nil {
+		if err := unpackLayer(ctx, store, layerDesc, opts.UnpackDir, relPath, opts.Overwrite, opts.IgnoreExisting, mediaType); err != nil {
 			return fmt.Errorf("failed to unpack: %w", err)
 		}
 	}

--- a/testing/pack-unpack_test.go
+++ b/testing/pack-unpack_test.go
@@ -262,3 +262,47 @@ datasets:
 		})
 	}
 }
+
+func TestPackUnpack_PreservesWorkingDir(t *testing.T) {
+	testPreflight(t)
+
+	tmpDir := setupTempDir(t)
+	modelKitPath, unpackPath, contextPath := setupTestDirs(t, tmpDir)
+	t.Setenv(constants.KitopsHomeEnvVar, contextPath)
+
+	testKitfile := `
+manifestVersion: 1.0.0
+package:
+  name: test-cwd
+model:
+  path: model.bin
+`
+	kitfilePath := filepath.Join(modelKitPath, constants.DefaultKitfileName)
+	if err := os.WriteFile(kitfilePath, []byte(testKitfile), 0644); err != nil {
+		t.Fatal(err)
+	}
+	setupFiles(t, modelKitPath, []string{"model.bin"})
+
+	origWd, err := os.Getwd()
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	tag := "test:cwd-check"
+	runCommand(t, expectNoError, "pack", modelKitPath, "-t", tag)
+
+	afterPackWd, err := os.Getwd()
+	if err != nil {
+		t.Fatal(err)
+	}
+	assert.Equal(t, origWd, afterPackWd, "kit pack should not change working directory")
+
+	runCommand(t, expectNoError, "unpack", tag, "-d", unpackPath)
+
+	afterUnpackWd, err := os.Getwd()
+	if err != nil {
+		t.Fatal(err)
+	}
+	assert.Equal(t, origWd, afterUnpackWd, "kit unpack should not change working directory")
+	checkFilesExistWithContent(t, unpackPath, []string{"model.bin"})
+}


### PR DESCRIPTION
### Description

This PR addresses #1269 by eliminating process-wide `os.Chdir` calls in `pack`, `unpack`, and `kitimport` operations in favor of explicit base paths.  

Changing the process working directory via `os.Chdir` mutated the caller's working directory and prevented safe concurrent execution.

### Key Changes
- **Pack pipeline**: Added `ContextDir` to `SaveModelOptions` in local-storage.go; updated tar and raw layer writers to resolve and walk paths relative
to `contextDir`. Removed `os.Chdir` from `pkg/cmd/pack/cmd.go` and `pkg/cmd/kitimport/util.go`.
- **Unpack pipeline**: Removed `os.Chdir` from `UnpackModelKit` and `unpackRemote` in core.go. Layers are now explicitly extracted and verified into   
target unpack destinations.
- **Tests**: Added `TestPackUnpack_PreservesWorkingDir` in pack-unpack_test.go verifying that neither `kit pack` nor `kit unpack` alters the process   
working directory.

### Testing
- `go test ./pkg/...` passed
- `go test ./...` passed (including all integration tests in `testing/`)

Fixes #1269