### PR TITLE
Drop empty trace log for license detection in Kitfile generation

### DIFF
--- a/pkg/lib/kitfile/generate/generate.go
+++ b/pkg/lib/kitfile/generate/generate.go
@@ -127,9 +127,10 @@ func GenerateKitfile(dir *DirectoryListing, packageOpt *artifact.Package, depth 
 		if err != nil {
 			output.Debugf("Error determining license type: %s", err)
 			output.Logf(output.LogLevelWarn, "Unable to determine license type")
+		} else {
+			detectedLicenseType = licenseType
+			output.Logf(output.LogLevelTrace, "Detected license %s for license file %s", detectedLicenseType, licensePath)
 		}
-		detectedLicenseType = licenseType
-		output.Logf(output.LogLevelTrace, "Detected license %s for license file", detectedLicenseType)
 	}
 
 	if len(unknownFiles) > 5 {


### PR DESCRIPTION
### Description
Trace logging for the detected license type logs unconditionally, leading to mysteriously empty logs when a license cannot be determined (e.g. `Detected license  for license file`). Instead, only log that trace line when a license has been found.

### Linked issues
N/A, minor fixup

### AI-Assisted Code
<!-- Check all that apply -->
- [ ] This PR contains AI-generated code that I have reviewed and tested
- [x] I take full responsibility for all code in this PR, regardless of how it was created
