### PR TITLE
fix(harness): fail fast on missing prerequisites in gen_common.sh

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -39,6 +39,7 @@ If you think there's something else you can help with please contact us in the [
 
 * Go (Golang): The latest version of Go, as the project is written in this language. Go's installation guide can be found at https://golang.org/doc/install.
 * Git: Version control system for cloning the repository and managing code changes. Installation instructions are available at https://git-scm.com/book/en/v2/Getting-Started-Installing-Git.
+* pnpm: Package manager used for building the dev mode harness UI and documentation. Installation instructions are available at https://pnpm.io/installation.
 
 ### Setting up the project
 

--- a/pkg/lib/harness/generated/gen_common.sh
+++ b/pkg/lib/harness/generated/gen_common.sh
@@ -1,6 +1,35 @@
 #!/bin/sh
 
-UI_DIR=../../../../frontend/dev-mode
+set -e
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" >/dev/null 2>&1 && pwd)"
+cd "$SCRIPT_DIR"
+
+UI_DIR="../../../../frontend/dev-mode"
+
+check_tool() {
+    TOOL=$1
+    HINT=$2
+    if ! command -v "$TOOL" >/dev/null 2>&1; then
+        echo "Error: '${TOOL}' is required but was not found on PATH." >&2
+        if [ -n "$HINT" ]; then
+            echo "$HINT" >&2
+        fi
+        exit 1
+    fi
+}
+
+check_tool go "Please install Go: https://golang.org/doc/install"
+check_tool node "Please install Node.js: https://nodejs.org/"
+check_tool pnpm "Please install pnpm: https://pnpm.io/installation"
+check_tool curl "Please install curl."
+check_tool tar "Please install tar."
+
+if ! command -v sha256sum >/dev/null 2>&1 && ! command -v shasum >/dev/null 2>&1; then
+    echo "Error: neither 'sha256sum' nor 'shasum' was found on PATH." >&2
+    exit 1
+fi
+
 LLAMAFILE_VER=$(go run ./llamafile_ver_helper.go)
 
 build_ui() {
@@ -8,15 +37,16 @@ build_ui() {
 
     echo "Building harness UI from ${UI_HOME}"
     
-    pushd ${UI_HOME}
-    pnpm install
-    pnpm run build
-    popd
+    (
+        cd "${UI_HOME}"
+        pnpm install
+        pnpm run build
+    )
 }
 
 compress() {
     echo "Compressing $1 to $2"
-    tar -czf $2 -C $1 .
+    tar -czf "$2" -C "$1" .
 }
 
 generate_sha() {
@@ -24,7 +54,11 @@ generate_sha() {
     CHECKSUM_FILE=$2
 
     echo "Generating SHA256 checksum for ${FILE}"
-    sha256sum ${FILE} | awk '{print $1 "  " FILENAME}' FILENAME="${FILE}" >> ${CHECKSUM_FILE}
+    if command -v sha256sum >/dev/null 2>&1; then
+        sha256sum "${FILE}" | awk '{print $1 "  " FILENAME}' FILENAME="${FILE}" >> "${CHECKSUM_FILE}"
+    else
+        shasum -a 256 "${FILE}" | awk '{print $1 "  " FILENAME}' FILENAME="${FILE}" >> "${CHECKSUM_FILE}"
+    fi
     echo "Checksum for ${FILE} saved to ${CHECKSUM_FILE}"
 }
 
@@ -41,27 +75,27 @@ download_github_release_binary() {
 
     DOWNLOAD_URL="https://github.com/${OWNER}/${REPO}/releases/download/${RELEASE_TAG}/llamafile-${RELEASE_TAG}"
     
-    mkdir -p ${OUTPUT_DIR}
+    mkdir -p "${OUTPUT_DIR}"
 
-    curl -L -o ${OUTPUT_DIR}/llamafile ${DOWNLOAD_URL}
+    curl -L -o "${OUTPUT_DIR}/llamafile" "${DOWNLOAD_URL}"
 
     echo "Asset '${ASSET_NAME}' downloaded successfully to: ${OUTPUT_DIR}/${ASSET_NAME}"
 
-    echo "${RELEASE_TAG}" > ${OUTPUT_DIR}/llamafile.version
+    echo "${RELEASE_TAG}" > "${OUTPUT_DIR}/llamafile.version"
 
     COMPRESSED_FILE="llamafile.tar.gz"
-    compress ${OUTPUT_DIR} ../${COMPRESSED_FILE}
+    compress "${OUTPUT_DIR}" "../${COMPRESSED_FILE}"
 
     echo "Compressed asset saved to: ${COMPRESSED_FILE}"
 }
 
-build_ui ${UI_DIR}
-compress ${UI_DIR}/dist ../ui.tar.gz
+build_ui "${UI_DIR}"
+compress "${UI_DIR}/dist" "../ui.tar.gz"
 download_github_release_binary "Mozilla-Ocho" "llamafile" "${LLAMAFILE_VER}" "llamafile-${LLAMAFILE_VER}" "./downloads"
 
 CHECKSUM_FILE="../checksums.txt"
-> ${CHECKSUM_FILE}  # Clear the checksum file if it exists
-generate_sha "../ui.tar.gz" ${CHECKSUM_FILE}
-generate_sha "../llamafile.tar.gz" ${CHECKSUM_FILE}
+> "${CHECKSUM_FILE}"  # Clear the checksum file if it exists
+generate_sha "../ui.tar.gz" "${CHECKSUM_FILE}"
+generate_sha "../llamafile.tar.gz" "${CHECKSUM_FILE}"
 
 echo "All checksums have been saved to ${CHECKSUM_FILE}"


### PR DESCRIPTION
### Description

When running `go generate ./...`, `pkg/lib/harness/generated/gen_common.sh` would previously fail silently if required tools like `pnpm` or `node` were missing, continuing into downstream commands and surfacing confusing errors (e.g., `tar: could not chdir to ...`).

This PR:
1. Adds `set -e` to `gen_common.sh` to halt on the first command error.
2. Adds preflight checks for required CLI tools (`go`, `node`, `pnpm`, `curl`, `tar`, and `sha256sum`/`shasum`) with clear, actionable installation instructions.
3. Replaces non-POSIX `pushd`/`popd` with POSIX subshell directory switching `(cd ... && ...)` for portability across different shells (e.g. `dash`).  
4. Adds macOS compatibility by falling back to `shasum -a 256` when `sha256sum` is unavailable.
5. Updates the Prerequisites section in `CONTRIBUTING.md` to list `pnpm`.

### Testing
- Verified `gen_common.sh` halts immediately and prints actionable error messages when tools are missing from PATH.
- Verified successful run of `go generate ./...` and `gen_common.sh` when prerequisites are present.
- `go test ./pkg/...` passed.

Fixes #1275
